### PR TITLE
make gcc_ar_wrapper python3 compatible to fix build crash

### DIFF
--- a/toolchain/gcc_ar_wrapper.py
+++ b/toolchain/gcc_ar_wrapper.py
@@ -15,6 +15,7 @@ import argparse
 import os
 import subprocess
 import sys
+import errno
 
 import wrapper_utils
 
@@ -55,7 +56,7 @@ def main():
   try:
     os.remove(args.output)
   except OSError as e:
-    if e.errno != os.errno.ENOENT:
+    if e.errno != errno.ENOENT:
       raise
 
   # Now just run the ar command.


### PR DESCRIPTION
If /usr/bin/python was python version 3 the build will fail on my system with the following
```
ninja: Entering directory `out'
[1/2] AR obj/lib.a
FAILED: obj/lib.a 
python "../build/toolchain/gcc_ar_wrapper.py" --output=obj/lib.a --ar="ar"  rcsD @"obj/lib.a.rsp"
Traceback (most recent call last):
  File "../build/toolchain/gcc_ar_wrapper.py", line 55, in main
    os.remove(args.output)
FileNotFoundError: [Errno 2] No such file or directory: 'obj/lib.a'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "../build/toolchain/gcc_ar_wrapper.py", line 65, in <module>
    sys.exit(main())
  File "../build/toolchain/gcc_ar_wrapper.py", line 57, in main
    if e.errno != os.errno.ENOENT:
AttributeError: module 'os' has no attribute 'errno'
ninja: build stopped: subcommand failed.
```
The commit makes the script python2 and python3 compatible and ninja can build successfully on both versions.