### PR TITLE
Better cross compilation support (gcc), small cleanups

### DIFF
--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -417,12 +417,10 @@ config("compiler_cpu_abi") {
         cflags += [ "--target=arm-linux-gnueabihf" ]
         ldflags += [ "--target=arm-linux-gnueabihf" ]
       }
-      if (!is_nacl) {
-        cflags += [
-          "-march=$arm_arch",
-          "-mfloat-abi=$arm_float_abi",
-        ]
-      }
+      cflags += [
+        "-march=$arm_arch",
+        "-mfloat-abi=$arm_float_abi",
+      ]
       if (arm_tune != "") {
         cflags += [ "-mtune=$arm_tune" ]
       }
@@ -431,7 +429,7 @@ config("compiler_cpu_abi") {
         cflags += [ "--target=aarch64-linux-gnu" ]
         ldflags += [ "--target=aarch64-linux-gnu" ]
       }
-    } else if (current_cpu == "mipsel" && !is_nacl) {
+    } else if (current_cpu == "mipsel") {
       if (mips_arch_variant == "r6") {
         if (is_clang) {
           cflags += [

--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -278,7 +278,6 @@ if (current_os == "win" || current_os == "winuwp") {
   is_ios = false
   is_linux = false
   is_mac = false
-  is_nacl = false
   is_posix = true
   is_win = false
   is_freebsd = false

--- a/config/arm.gni
+++ b/config/arm.gni
@@ -58,6 +58,7 @@ if (current_cpu == "arm") {
       arm_fpu = "vfp"
     }
     arm_use_thumb = false
+    arm_use_neon = false
   } else if (arm_version == 7) {
     if (arm_arch == "") {
       arm_arch = "armv7-a"


### PR DESCRIPTION
There are 3 patches:
1) removes last pieces of NaCl (target_cpu="arm" was causing issues for me)
2) disables neon for ARMv6
3) allows to specify gcc prefix like arm-linux-gnueabihf-. Here is example:

`gn gen --args="is_clang=false toolchain_prefix=\"arm-linux-gnueabihf-\" target_sysroot=\"/arm-buildroot-linux-gnueabihf/sysroot\" target_cpu=\"arm\" target_os=\"linux\"" out`

In fact it was possible to get the same result overriding gcc_cc, gcc_cxx and a 4 other but it does not look like proper way - command line looks horrible. As for now both ways are supported.
