### PR TITLE
replaced all occurences of "//build/" with "$gn_root/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ branch contains the test/example project used by the CI tests.
 All variables described here are build args and can be overridden in the user's
 `args.gn` file.
 
-#### [`$gn_build_dir/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn)
+#### [`$gn_root/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn)
 
 (these variables are available everywhere)
 
@@ -37,7 +37,7 @@ All variables described here are build args and can be overridden in the user's
   By convention, all 3rd-party projects should end up in this directory, so they
   can depend on each other (e.g. $external/mysql_connector -> $external/zlib)
 
-#### [`$gn_build_dir/toolchain/clang.gni`](toolchain/clang.gni)
+#### [`$gn_root/toolchain/clang.gni`](toolchain/clang.gni)
 
 * `use_lld` (default: false): Use the new LLD linker.
   This requires `is_clang` to be true.
@@ -45,7 +45,7 @@ All variables described here are build args and can be overridden in the user's
   (without /bin). If you use Clang on Windows, you are required to set this,
   as the Clang installation isn't automatically detected.
 
-#### [`$gn_build_dir/toolchain/compiler_version.gni`](toolchain/compiler_version.gni)
+#### [`$gn_root/toolchain/compiler_version.gni`](toolchain/compiler_version.gni)
 
 * `gcc_version` (default: auto-detected): Version of the GCC compiler.
   **Note:** Auto-detection is toolchain-specific and happens only if GCC is the
@@ -64,7 +64,7 @@ All variables described here are build args and can be overridden in the user's
 
 ### Windows toolchain
 
-#### [`$gn_build_dir/toolchain/win/settings.gni`](toolchain/win/settings.gni)
+#### [`$gn_root/toolchain/win/settings.gni`](toolchain/win/settings.gni)
 
 * `visual_studio_version` (default: "latest"): Desired version of Visual Studio.
   If `visual_studio_path` is set, this must be the version of the VS installation
@@ -86,7 +86,7 @@ All variables described here are build args and can be overridden in the user's
 This is the default toolchain for POSIX operating systems,
 which is used for all POSIX systems that don't have special toolchains.
 
-#### [`$gn_build_dir/toolchain/posix/settings.gni`](toolchain/posix/settings.gni)
+#### [`$gn_root/toolchain/posix/settings.gni`](toolchain/posix/settings.gni)
 
 * `gcc_cc` (default: gcc): Path of the GCC C compiler executable.
   Does not have to be absolute.
@@ -101,7 +101,7 @@ which is used for all POSIX systems that don't have special toolchains.
 
 ### Mac/iOS toolchain
 
-#### [`$gn_build_dir/toolchain/mac/settings.gni`](toolchain/mac/settings.gni)
+#### [`$gn_root/toolchain/mac/settings.gni`](toolchain/mac/settings.gni)
 
 * `use_system_xcode` (default: true): Use the system install of Xcode for tools
   like ibtool, libtool, etc. This does not affect the compiler. When this
@@ -113,17 +113,17 @@ which is used for all POSIX systems that don't have special toolchains.
   `clang_base_path` needs to be set.
 * `enable_dsyms` (default: true): Produce dSYM files for targets that are
   configured to do so. dSYM generation is controlled globally as it is a
-  linker output (produced via the `$gn_build_dir/toolchain/mac/linker_driver.py`.
+  linker output (produced via the `$gn_root/toolchain/mac/linker_driver.py`.
   Enabling this will result in all shared library, loadable module, and
   executable targets having a dSYM generated.
 * `enable_stripping` (default: `is_official_build`): Strip symbols from linked
-  targets by default. If this is enabled, the $gn_build_dir/config/mac:strip_all
+  targets by default. If this is enabled, the $gn_root/config/mac:strip_all
   config will be applied to all linked targets. If custom stripping parameters
   are required, remove that config from a linked target and apply custom
-  `-Wcrl,strip` flags. See $gn_build_dir/toolchain/mac/linker_driver.py for more
+  `-Wcrl,strip` flags. See $gn_root/toolchain/mac/linker_driver.py for more
   information.
 
-#### [`$gn_build_dir/toolchain/mac/mac_sdk.gni`](toolchain/mac/mac_sdk.gni)
+#### [`$gn_root/toolchain/mac/mac_sdk.gni`](toolchain/mac/mac_sdk.gni)
 
 * `mac_sdk_min` (default: "10.10"): Minimum supported version of the Mac SDK.
 * `mac_deployment_target` (default: "10.9"): Minimum supported version of OSX.
@@ -132,7 +132,7 @@ which is used for all POSIX systems that don't have special toolchains.
   greater than or equal to `mac_sdk_min` is used.
 * `mac_sdk_name` (default: "macosx"): The SDK name as accepted by xcodebuild.
 
-#### [`$gn_build_dir/toolchain/mac/ios_sdk.gni`](toolchain/mac/ios_sdk.gni)
+#### [`$gn_root/toolchain/mac/ios_sdk.gni`](toolchain/mac/ios_sdk.gni)
 
 * `ios_sdk_path` (default: ""): Path to a specific version of the iOS SDK, not
   including a slash at the end. When empty this will use the default SDK based
@@ -152,7 +152,7 @@ which is used for all POSIX systems that don't have special toolchains.
 
 ### Android toolchain
 
-#### [`$gn_build_dir/toolchain/android/settings.gni`](toolchain/android/settings.gni)
+#### [`$gn_root/toolchain/android/settings.gni`](toolchain/android/settings.gni)
 
 * `android_ndk_root` (default: "$external/android_tools/ndk"):
   Path of the Android NDK.
@@ -180,6 +180,6 @@ it is recommended that you refrain from modifying large parts of the toolchains/
 If changes are necessary, consider contributing them back ;)
 
 For more complex projects, it might be feasible to use a custom build-config file
-that just `import()s` [`$gn_build_dir/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn) and then overrides
+that just `import()s` [`$gn_root/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn) and then overrides
 the defaults set inside `BUILDCONFIG.gn`. There's also GN's `default_args` scope, which can be used
 to provide project-specific argument overrides.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ branch contains the test/example project used by the CI tests.
 All variables described here are build args and can be overridden in the user's
 `args.gn` file.
 
-#### [`//build/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn)
+#### [`$gn_build_dir/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn)
 
 (these variables are available everywhere)
 
@@ -37,7 +37,7 @@ All variables described here are build args and can be overridden in the user's
   By convention, all 3rd-party projects should end up in this directory, so they
   can depend on each other (e.g. $external/mysql_connector -> $external/zlib)
 
-#### [`//build/toolchain/clang.gni`](toolchain/clang.gni)
+#### [`$gn_build_dir/toolchain/clang.gni`](toolchain/clang.gni)
 
 * `use_lld` (default: false): Use the new LLD linker.
   This requires `is_clang` to be true.
@@ -45,7 +45,7 @@ All variables described here are build args and can be overridden in the user's
   (without /bin). If you use Clang on Windows, you are required to set this,
   as the Clang installation isn't automatically detected.
 
-#### [`//build/toolchain/compiler_version.gni`](toolchain/compiler_version.gni)
+#### [`$gn_build_dir/toolchain/compiler_version.gni`](toolchain/compiler_version.gni)
 
 * `gcc_version` (default: auto-detected): Version of the GCC compiler.
   **Note:** Auto-detection is toolchain-specific and happens only if GCC is the
@@ -64,7 +64,7 @@ All variables described here are build args and can be overridden in the user's
 
 ### Windows toolchain
 
-#### [`//build/toolchain/win/settings.gni`](toolchain/win/settings.gni)
+#### [`$gn_build_dir/toolchain/win/settings.gni`](toolchain/win/settings.gni)
 
 * `visual_studio_version` (default: "latest"): Desired version of Visual Studio.
   If `visual_studio_path` is set, this must be the version of the VS installation
@@ -86,7 +86,7 @@ All variables described here are build args and can be overridden in the user's
 This is the default toolchain for POSIX operating systems,
 which is used for all POSIX systems that don't have special toolchains.
 
-#### [`//build/toolchain/posix/settings.gni`](toolchain/posix/settings.gni)
+#### [`$gn_build_dir/toolchain/posix/settings.gni`](toolchain/posix/settings.gni)
 
 * `gcc_cc` (default: gcc): Path of the GCC C compiler executable.
   Does not have to be absolute.
@@ -101,7 +101,7 @@ which is used for all POSIX systems that don't have special toolchains.
 
 ### Mac/iOS toolchain
 
-#### [`//build/toolchain/mac/settings.gni`](toolchain/mac/settings.gni)
+#### [`$gn_build_dir/toolchain/mac/settings.gni`](toolchain/mac/settings.gni)
 
 * `use_system_xcode` (default: true): Use the system install of Xcode for tools
   like ibtool, libtool, etc. This does not affect the compiler. When this
@@ -113,17 +113,17 @@ which is used for all POSIX systems that don't have special toolchains.
   `clang_base_path` needs to be set.
 * `enable_dsyms` (default: true): Produce dSYM files for targets that are
   configured to do so. dSYM generation is controlled globally as it is a
-  linker output (produced via the `//build/toolchain/mac/linker_driver.py`.
+  linker output (produced via the `$gn_build_dir/toolchain/mac/linker_driver.py`.
   Enabling this will result in all shared library, loadable module, and
   executable targets having a dSYM generated.
 * `enable_stripping` (default: `is_official_build`): Strip symbols from linked
-  targets by default. If this is enabled, the //build/config/mac:strip_all
+  targets by default. If this is enabled, the $gn_build_dir/config/mac:strip_all
   config will be applied to all linked targets. If custom stripping parameters
   are required, remove that config from a linked target and apply custom
-  `-Wcrl,strip` flags. See //build/toolchain/mac/linker_driver.py for more
+  `-Wcrl,strip` flags. See $gn_build_dir/toolchain/mac/linker_driver.py for more
   information.
 
-#### [`//build/toolchain/mac/mac_sdk.gni`](toolchain/mac/mac_sdk.gni)
+#### [`$gn_build_dir/toolchain/mac/mac_sdk.gni`](toolchain/mac/mac_sdk.gni)
 
 * `mac_sdk_min` (default: "10.10"): Minimum supported version of the Mac SDK.
 * `mac_deployment_target` (default: "10.9"): Minimum supported version of OSX.
@@ -132,7 +132,7 @@ which is used for all POSIX systems that don't have special toolchains.
   greater than or equal to `mac_sdk_min` is used.
 * `mac_sdk_name` (default: "macosx"): The SDK name as accepted by xcodebuild.
 
-#### [`//build/toolchain/mac/ios_sdk.gni`](toolchain/mac/ios_sdk.gni)
+#### [`$gn_build_dir/toolchain/mac/ios_sdk.gni`](toolchain/mac/ios_sdk.gni)
 
 * `ios_sdk_path` (default: ""): Path to a specific version of the iOS SDK, not
   including a slash at the end. When empty this will use the default SDK based
@@ -152,7 +152,7 @@ which is used for all POSIX systems that don't have special toolchains.
 
 ### Android toolchain
 
-#### [`//build/toolchain/android/settings.gni`](toolchain/android/settings.gni)
+#### [`$gn_build_dir/toolchain/android/settings.gni`](toolchain/android/settings.gni)
 
 * `android_ndk_root` (default: "$external/android_tools/ndk"):
   Path of the Android NDK.
@@ -180,6 +180,6 @@ it is recommended that you refrain from modifying large parts of the toolchains/
 If changes are necessary, consider contributing them back ;)
 
 For more complex projects, it might be feasible to use a custom build-config file
-that just `import()s` [`//build/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn) and then overrides
+that just `import()s` [`$gn_build_dir/config/BUILDCONFIG.gn`](config/BUILDCONFIG.gn) and then overrides
 the defaults set inside `BUILDCONFIG.gn`. There's also GN's `default_args` scope, which can be used
 to provide project-specific argument overrides.

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -2,28 +2,28 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/config/compiler.gni")
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
-import("$gn_build_dir/toolchain/clang.gni")
+import("$gn_root/config/compiler.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
+import("$gn_root/toolchain/toolchain.gni")
+import("$gn_root/toolchain/clang.gni")
 
 if (current_cpu == "arm" || current_cpu == "arm64") {
-  import("$gn_build_dir/config/arm.gni")
+  import("$gn_root/config/arm.gni")
 }
 
 if (current_cpu == "mipsel" || current_cpu == "mips64el") {
-  import("$gn_build_dir/config/mips.gni")
+  import("$gn_root/config/mips.gni")
 }
 
 if (is_mac) {
-  import("$gn_build_dir/toolchain/mac/settings.gni")
+  import("$gn_root/toolchain/mac/settings.gni")
 }
 
 if (is_android) {
-  import("$gn_build_dir/toolchain/android/settings.gni")
+  import("$gn_root/toolchain/android/settings.gni")
 }
 
-import("$gn_build_dir/toolchain/compiler_version.gni")
+import("$gn_root/toolchain/compiler_version.gni")
 
 declare_args() {
   # Whether or not we should turn on incremental LTCG. Only affects the VS
@@ -133,16 +133,16 @@ config("compiler") {
   # categories here, add it to the associated file to keep this shared config
   # smaller.
   if (is_win) {
-    configs += [ "$gn_build_dir/config/win:compiler" ]
+    configs += [ "$gn_root/config/win:compiler" ]
   } else if (is_android) {
-    configs += [ "$gn_build_dir/config/android:compiler" ]
+    configs += [ "$gn_root/config/android:compiler" ]
   } else if (is_ios || is_mac) {
-    configs += [ "$gn_build_dir/config/mac:compiler" ]
+    configs += [ "$gn_root/config/mac:compiler" ]
   }
 
   # Applies to all Posix systems.
   if (is_posix) {
-    configs += [ "$gn_build_dir/config/posix:compiler" ]
+    configs += [ "$gn_root/config/posix:compiler" ]
   }
 
   # See the definitions below.
@@ -383,7 +383,7 @@ config("extra_flags") {
 
 # This is separate from :compiler (and not even a sub-config there)
 # so that some targets can remove it from the list with:
-#   configs -= [ "$gn_build_dir/config:pthread" ]
+#   configs -= [ "$gn_root/config:pthread" ]
 config("pthread") {
   if (is_linux || is_freebsd) {
     cflags = [ "-pthread" ]
@@ -601,7 +601,7 @@ config("stack_protection") {
 
 # This is separate from :compiler_codegen (and not even a sub-config there)
 # so that some targets can remove it from the list with:
-#   configs -= [ "$gn_build_dir/config/compiler:stackrealign" ]
+#   configs -= [ "$gn_root/config/compiler:stackrealign" ]
 config("stackrealign") {
   if (current_cpu == "x86") {
     if (is_clang && (is_freebsd || is_linux)) {
@@ -757,17 +757,17 @@ config("runtime_library") {
   # categories here, add it to the associated file to keep this shared config
   # smaller.
   if (is_win) {
-    configs += [ "$gn_build_dir/config/win:runtime_library" ]
+    configs += [ "$gn_root/config/win:runtime_library" ]
   } else if (is_ios) {
-    configs += [ "$gn_build_dir/config/ios:runtime_library" ]
+    configs += [ "$gn_root/config/ios:runtime_library" ]
   } else if (is_mac) {
-    configs += [ "$gn_build_dir/config/mac:runtime_library" ]
+    configs += [ "$gn_root/config/mac:runtime_library" ]
   } else if (is_android) {
-    configs += [ "$gn_build_dir/config/android:runtime_library" ]
+    configs += [ "$gn_root/config/android:runtime_library" ]
   }
 
   if (is_posix) {
-    configs += [ "$gn_build_dir/config/posix:runtime_library" ]
+    configs += [ "$gn_root/config/posix:runtime_library" ]
   }
 }
 
@@ -888,8 +888,8 @@ config("no_incompatible_pointer_warnings") {
 # You can override the optimization level on a per-target basis by removing the
 # default config and then adding the named one you want:
 #
-#   configs -= [ "$gn_build_dir/config/compiler:default_optimization" ]
-#   configs += [ "$gn_build_dir/config/compiler:optimize_max" ]
+#   configs -= [ "$gn_root/config/compiler:default_optimization" ]
+#   configs += [ "$gn_root/config/compiler:optimize_max" ]
 
 # Shared settings for both "optimize" and "optimize_max" configs.
 # IMPORTANT: On Windows "/O1" and "/O2" must go before the common flags.
@@ -1140,8 +1140,8 @@ config("afdo") {
 # You can override the symbol level on a per-target basis by removing the
 # default config and then adding the named one you want:
 #
-#   configs -= [ "$gn_build_dir/config:default_symbols" ]
-#   configs += [ "$gn_build_dir/config:symbols" ]
+#   configs -= [ "$gn_root/config:default_symbols" ]
+#   configs += [ "$gn_root/config:symbols" ]
 
 # Full symbols.
 config("symbols") {
@@ -1314,8 +1314,8 @@ config("default_libs") {
 # Windows linker setup for EXEs and DLLs.
 if (is_win) {
   _windows_linker_configs = [
-    "$gn_build_dir/config/win:sdk_link",
-    "$gn_build_dir/config/win:common_linker_setup",
+    "$gn_root/config/win:sdk_link",
+    "$gn_root/config/win:common_linker_setup",
   ]
 }
 
@@ -1327,15 +1327,15 @@ config("executable_config") {
     configs += _windows_linker_configs
   } else if (is_mac) {
     configs += [
-      "$gn_build_dir/config/mac:mac_dynamic_flags",
-      "$gn_build_dir/config/mac:mac_executable_flags",
+      "$gn_root/config/mac:mac_dynamic_flags",
+      "$gn_root/config/mac:mac_executable_flags",
     ]
   } else if (is_ios) {
-    configs += [ "$gn_build_dir/config/ios:ios_dynamic_flags" ]
+    configs += [ "$gn_root/config/ios:ios_dynamic_flags" ]
   } else if (is_posix) {
-    configs += [ "$gn_build_dir/config/posix:executable_ldconfig" ]
+    configs += [ "$gn_root/config/posix:executable_ldconfig" ]
     if (is_android) {
-      configs += [ "$gn_build_dir/config/android:executable_config" ]
+      configs += [ "$gn_root/config/android:executable_config" ]
     }
   }
 }
@@ -1349,8 +1349,8 @@ config("shared_library_config") {
   if (is_win) {
     configs += _windows_linker_configs
   } else if (is_mac) {
-    configs += [ "$gn_build_dir/config/mac:mac_dynamic_flags" ]
+    configs += [ "$gn_root/config/mac:mac_dynamic_flags" ]
   } else if (is_ios) {
-    configs += [ "$gn_build_dir/config/ios:ios_dynamic_flags" ]
+    configs += [ "$gn_root/config/ios:ios_dynamic_flags" ]
   }
 }

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -2,28 +2,28 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/compiler.gni")
-import("//build/config/sanitizers/sanitizers.gni")
-import("//build/toolchain/toolchain.gni")
-import("//build/toolchain/clang.gni")
+import("$gn_build_dir/config/compiler.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_build_dir/toolchain/clang.gni")
 
 if (current_cpu == "arm" || current_cpu == "arm64") {
-  import("//build/config/arm.gni")
+  import("$gn_build_dir/config/arm.gni")
 }
 
 if (current_cpu == "mipsel" || current_cpu == "mips64el") {
-  import("//build/config/mips.gni")
+  import("$gn_build_dir/config/mips.gni")
 }
 
 if (is_mac) {
-  import("//build/toolchain/mac/settings.gni")
+  import("$gn_build_dir/toolchain/mac/settings.gni")
 }
 
 if (is_android) {
-  import("//build/toolchain/android/settings.gni")
+  import("$gn_build_dir/toolchain/android/settings.gni")
 }
 
-import("//build/toolchain/compiler_version.gni")
+import("$gn_build_dir/toolchain/compiler_version.gni")
 
 declare_args() {
   # Whether or not we should turn on incremental LTCG. Only affects the VS
@@ -133,16 +133,16 @@ config("compiler") {
   # categories here, add it to the associated file to keep this shared config
   # smaller.
   if (is_win) {
-    configs += [ "//build/config/win:compiler" ]
+    configs += [ "$gn_build_dir/config/win:compiler" ]
   } else if (is_android) {
-    configs += [ "//build/config/android:compiler" ]
+    configs += [ "$gn_build_dir/config/android:compiler" ]
   } else if (is_ios || is_mac) {
-    configs += [ "//build/config/mac:compiler" ]
+    configs += [ "$gn_build_dir/config/mac:compiler" ]
   }
 
   # Applies to all Posix systems.
   if (is_posix) {
-    configs += [ "//build/config/posix:compiler" ]
+    configs += [ "$gn_build_dir/config/posix:compiler" ]
   }
 
   # See the definitions below.
@@ -383,7 +383,7 @@ config("extra_flags") {
 
 # This is separate from :compiler (and not even a sub-config there)
 # so that some targets can remove it from the list with:
-#   configs -= [ "//build/config:pthread" ]
+#   configs -= [ "$gn_build_dir/config:pthread" ]
 config("pthread") {
   if (is_linux || is_freebsd) {
     cflags = [ "-pthread" ]
@@ -601,7 +601,7 @@ config("stack_protection") {
 
 # This is separate from :compiler_codegen (and not even a sub-config there)
 # so that some targets can remove it from the list with:
-#   configs -= [ "//build/config/compiler:stackrealign" ]
+#   configs -= [ "$gn_build_dir/config/compiler:stackrealign" ]
 config("stackrealign") {
   if (current_cpu == "x86") {
     if (is_clang && (is_freebsd || is_linux)) {
@@ -757,17 +757,17 @@ config("runtime_library") {
   # categories here, add it to the associated file to keep this shared config
   # smaller.
   if (is_win) {
-    configs += [ "//build/config/win:runtime_library" ]
+    configs += [ "$gn_build_dir/config/win:runtime_library" ]
   } else if (is_ios) {
-    configs += [ "//build/config/ios:runtime_library" ]
+    configs += [ "$gn_build_dir/config/ios:runtime_library" ]
   } else if (is_mac) {
-    configs += [ "//build/config/mac:runtime_library" ]
+    configs += [ "$gn_build_dir/config/mac:runtime_library" ]
   } else if (is_android) {
-    configs += [ "//build/config/android:runtime_library" ]
+    configs += [ "$gn_build_dir/config/android:runtime_library" ]
   }
 
   if (is_posix) {
-    configs += [ "//build/config/posix:runtime_library" ]
+    configs += [ "$gn_build_dir/config/posix:runtime_library" ]
   }
 }
 
@@ -888,8 +888,8 @@ config("no_incompatible_pointer_warnings") {
 # You can override the optimization level on a per-target basis by removing the
 # default config and then adding the named one you want:
 #
-#   configs -= [ "//build/config/compiler:default_optimization" ]
-#   configs += [ "//build/config/compiler:optimize_max" ]
+#   configs -= [ "$gn_build_dir/config/compiler:default_optimization" ]
+#   configs += [ "$gn_build_dir/config/compiler:optimize_max" ]
 
 # Shared settings for both "optimize" and "optimize_max" configs.
 # IMPORTANT: On Windows "/O1" and "/O2" must go before the common flags.
@@ -1140,8 +1140,8 @@ config("afdo") {
 # You can override the symbol level on a per-target basis by removing the
 # default config and then adding the named one you want:
 #
-#   configs -= [ "//build/config:default_symbols" ]
-#   configs += [ "//build/config:symbols" ]
+#   configs -= [ "$gn_build_dir/config:default_symbols" ]
+#   configs += [ "$gn_build_dir/config:symbols" ]
 
 # Full symbols.
 config("symbols") {
@@ -1314,8 +1314,8 @@ config("default_libs") {
 # Windows linker setup for EXEs and DLLs.
 if (is_win) {
   _windows_linker_configs = [
-    "//build/config/win:sdk_link",
-    "//build/config/win:common_linker_setup",
+    "$gn_build_dir/config/win:sdk_link",
+    "$gn_build_dir/config/win:common_linker_setup",
   ]
 }
 
@@ -1327,15 +1327,15 @@ config("executable_config") {
     configs += _windows_linker_configs
   } else if (is_mac) {
     configs += [
-      "//build/config/mac:mac_dynamic_flags",
-      "//build/config/mac:mac_executable_flags",
+      "$gn_build_dir/config/mac:mac_dynamic_flags",
+      "$gn_build_dir/config/mac:mac_executable_flags",
     ]
   } else if (is_ios) {
-    configs += [ "//build/config/ios:ios_dynamic_flags" ]
+    configs += [ "$gn_build_dir/config/ios:ios_dynamic_flags" ]
   } else if (is_posix) {
-    configs += [ "//build/config/posix:executable_ldconfig" ]
+    configs += [ "$gn_build_dir/config/posix:executable_ldconfig" ]
     if (is_android) {
-      configs += [ "//build/config/android:executable_config" ]
+      configs += [ "$gn_build_dir/config/android:executable_config" ]
     }
   }
 }
@@ -1349,8 +1349,8 @@ config("shared_library_config") {
   if (is_win) {
     configs += _windows_linker_configs
   } else if (is_mac) {
-    configs += [ "//build/config/mac:mac_dynamic_flags" ]
+    configs += [ "$gn_build_dir/config/mac:mac_dynamic_flags" ]
   } else if (is_ios) {
-    configs += [ "//build/config/ios:ios_dynamic_flags" ]
+    configs += [ "$gn_build_dir/config/ios:ios_dynamic_flags" ]
   }
 }

--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -46,6 +46,9 @@
 # When writing build files, to do something only for the host:
 #   if (current_toolchain == host_toolchain) { ...
 
+  # Path of the //build dir, which is the current parent folder.
+  gn_root = get_path_info(get_path_info("..", "abspath"), "dir")
+
 if (target_os == "") {
   target_os = host_os
 }
@@ -88,7 +91,7 @@ if (current_os == "") {
 #   Nobody else in the build needs to see the flag.
 #
 # - Defines based on build variables should be implemented via the generated
-#   build flag header system. See $gn_build_dir/buildflag_header.gni. You can put
+#   build flag header system. See $gn_root/buildflag_header.gni. You can put
 #   the buildflag_header target in the same file as the build flag itself. You
 #   should almost never set "defines" directly.
 #
@@ -146,8 +149,7 @@ declare_args() {
   # can depend on each other (e.g. $external/mysql_connector -> $external/zlib)
   external = "//external"
 
-  # Path of the //build dir, which is the current parent folder.
-  gn_build_dir = get_path_info(get_path_info("..", "abspath"), "dir")
+
 
   # DON'T ADD MORE FLAGS HERE. Read the comment above.
 }
@@ -179,14 +181,14 @@ if (host_toolchain == "") {
   # no toolchain omitted host_toolchain from its toolchain_args().
 
   if (host_os == "mac") {
-    host_toolchain = "$gn_build_dir/toolchain/mac:clang_$host_cpu"
+    host_toolchain = "$gn_root/toolchain/mac:clang_$host_cpu"
   } else if (host_os == "win") {
     # On Windows always use the target CPU for host builds. On the
     # configurations we support this will always work and it saves build steps.
     if (is_clang) {
-      host_toolchain = "$gn_build_dir/toolchain/win:clang_$target_cpu"
+      host_toolchain = "$gn_root/toolchain/win:clang_$target_cpu"
     } else {
-      host_toolchain = "$gn_build_dir/toolchain/win:$target_cpu"
+      host_toolchain = "$gn_root/toolchain/win:$target_cpu"
     }
   } else {
     if (target_os != host_os) {
@@ -194,11 +196,11 @@ if (host_toolchain == "") {
       # build, and there is no way to indicate that you want to override
       # it for both the target build *and* the host build. Do we need to
       # support this?
-      host_toolchain = "$gn_build_dir/toolchain/posix:clang_$host_cpu"
+      host_toolchain = "$gn_root/toolchain/posix:clang_$host_cpu"
     } else if (is_clang) {
-      host_toolchain = "$gn_build_dir/toolchain/posix:clang_$host_cpu"
+      host_toolchain = "$gn_root/toolchain/posix:clang_$host_cpu"
     } else {
-      host_toolchain = "$gn_build_dir/toolchain/posix:$host_cpu"
+      host_toolchain = "$gn_root/toolchain/posix:$host_cpu"
     }
   }
 }
@@ -207,12 +209,12 @@ _default_toolchain = ""
 
 if (target_os == "android") {
   if (is_clang) {
-    _default_toolchain = "$gn_build_dir/toolchain/android:android_clang_$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/android:android_clang_$target_cpu"
   } else {
-    _default_toolchain = "$gn_build_dir/toolchain/android:android_$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/android:android_$target_cpu"
   }
 } else if (target_os == "ios") {
-  _default_toolchain = "$gn_build_dir/toolchain/mac:ios_clang_$target_cpu"
+  _default_toolchain = "$gn_root/toolchain/mac:ios_clang_$target_cpu"
 } else if (target_os == "mac") {
   assert(host_os == "mac", "Mac cross-compiles are unsupported.")
   _default_toolchain = host_toolchain
@@ -220,21 +222,21 @@ if (target_os == "android") {
   # On Windows we use the same toolchain for host and target by default.
   assert(target_os == host_os, "Win cross-compiles only work on win hosts.")
   if (is_clang) {
-    _default_toolchain = "$gn_build_dir/toolchain/win:clang_$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/win:clang_$target_cpu"
   } else {
-    _default_toolchain = "$gn_build_dir/toolchain/win:$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/win:$target_cpu"
   }
 } else if (target_os == "winuwp") {
   # Only target WinUWP on for a Windows store application and only
   # x86, x64 and arm are supported target CPUs.
   assert(target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm" ||
          target_cpu == "arm64")
-  _default_toolchain = "$gn_build_dir/toolchain/win:uwp_$target_cpu"
+  _default_toolchain = "$gn_root/toolchain/win:uwp_$target_cpu"
 } else {
   if (is_clang) {
-    _default_toolchain = "$gn_build_dir/toolchain/posix:clang_$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/posix:clang_$target_cpu"
   } else {
-    _default_toolchain = "$gn_build_dir/toolchain/posix:$target_cpu"
+    _default_toolchain = "$gn_root/toolchain/posix:$target_cpu"
   }
 }
 
@@ -322,42 +324,42 @@ if (current_os == "win" || current_os == "winuwp") {
 
 # Holds all configs used for running the compiler.
 default_compiler_configs = [
-  "$gn_build_dir/config:extra_flags",
-  "$gn_build_dir/config:afdo",
-  "$gn_build_dir/config:compiler",
-  "$gn_build_dir/config:pthread",
-  "$gn_build_dir/config:stackrealign",
-  "$gn_build_dir/config:compiler_arm_fpu",
-  "$gn_build_dir/config:compiler_arm_thumb",
-  "$gn_build_dir/config:default_optimization",
-  "$gn_build_dir/config:default_stack_frames",
-  "$gn_build_dir/config:default_symbols",
-  "$gn_build_dir/config:c++11",
-  "$gn_build_dir/config:rtti",
-  "$gn_build_dir/config:exceptions",
-  "$gn_build_dir/config:runtime_library",
-  "$gn_build_dir/config:symbol_visibility_hidden",
+  "$gn_root/config:extra_flags",
+  "$gn_root/config:afdo",
+  "$gn_root/config:compiler",
+  "$gn_root/config:pthread",
+  "$gn_root/config:stackrealign",
+  "$gn_root/config:compiler_arm_fpu",
+  "$gn_root/config:compiler_arm_thumb",
+  "$gn_root/config:default_optimization",
+  "$gn_root/config:default_stack_frames",
+  "$gn_root/config:default_symbols",
+  "$gn_root/config:c++11",
+  "$gn_root/config:rtti",
+  "$gn_root/config:exceptions",
+  "$gn_root/config:runtime_library",
+  "$gn_root/config:symbol_visibility_hidden",
 ]
 if (is_win) {
   default_compiler_configs += [
-    "$gn_build_dir/config/win:default_crt",
-    "$gn_build_dir/config/win:lean_and_mean",
-    "$gn_build_dir/config/win:nominmax",
-    "$gn_build_dir/config/win:winver",
-    "$gn_build_dir/config/win:vs_code_analysis",
+    "$gn_root/config/win:default_crt",
+    "$gn_root/config/win:lean_and_mean",
+    "$gn_root/config/win:nominmax",
+    "$gn_root/config/win:winver",
+    "$gn_root/config/win:vs_code_analysis",
   ]
 }
 
 if (is_android) {
   default_compiler_configs +=
-      [ "$gn_build_dir/config/android:default_cygprofile_instrumentation" ]
+      [ "$gn_root/config/android:default_cygprofile_instrumentation" ]
 }
 
 # Debug/release-related defines.
 if (is_debug) {
-  default_compiler_configs += [ "$gn_build_dir/config:debug" ]
+  default_compiler_configs += [ "$gn_root/config:debug" ]
 } else {
-  default_compiler_configs += [ "$gn_build_dir/config:release" ]
+  default_compiler_configs += [ "$gn_root/config:release" ]
 }
 
 # Static libraries and source sets use only the compiler ones.
@@ -373,24 +375,24 @@ set_defaults("source_set") {
 if (is_win) {
   # Windows linker setup for EXEs and DLLs.
   # Many targets remove these configs, so they are not contained within
-  # $gn_build_dir/config:executable_config for easy removal.
+  # $gn_root/config:executable_config for easy removal.
   _linker_configs = [
-    "$gn_build_dir/config/win:default_incremental_linking",
+    "$gn_root/config/win:default_incremental_linking",
 
     # Default to console-mode apps. Most of our targets are tests and such
     # that shouldn't use the windows subsystem.
-    "$gn_build_dir/config/win:console",
+    "$gn_root/config/win:console",
   ]
 } else if (is_mac || is_ios) {
-  _linker_configs = [ "$gn_build_dir/config/mac:strip_all" ]
+  _linker_configs = [ "$gn_root/config/mac:strip_all" ]
 } else {
   _linker_configs = []
 }
 
 # Executable defaults.
 default_executable_configs = default_compiler_configs + [
-                               "$gn_build_dir/config:default_libs",
-                               "$gn_build_dir/config:executable_config",
+                               "$gn_root/config:default_libs",
+                               "$gn_root/config:executable_config",
                              ] + _linker_configs
 set_defaults("executable") {
   configs = default_executable_configs
@@ -399,8 +401,8 @@ set_defaults("executable") {
 # Shared library and loadable module defaults (also for components in component
 # mode).
 default_shared_library_configs = default_compiler_configs + [
-                                   "$gn_build_dir/config:default_libs",
-                                   "$gn_build_dir/config:shared_library_config",
+                                   "$gn_root/config:default_libs",
+                                   "$gn_root/config:shared_library_config",
                                  ] + _linker_configs
 
 set_defaults("shared_library") {

--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -88,7 +88,7 @@ if (current_os == "") {
 #   Nobody else in the build needs to see the flag.
 #
 # - Defines based on build variables should be implemented via the generated
-#   build flag header system. See //build/buildflag_header.gni. You can put
+#   build flag header system. See $gn_build_dir/buildflag_header.gni. You can put
 #   the buildflag_header target in the same file as the build flag itself. You
 #   should almost never set "defines" directly.
 #
@@ -146,6 +146,9 @@ declare_args() {
   # can depend on each other (e.g. $external/mysql_connector -> $external/zlib)
   external = "//external"
 
+  # Path of the //build dir, which is the current parent folder.
+  gn_build_dir = get_path_info(get_path_info("..", "abspath"), "dir")
+
   # DON'T ADD MORE FLAGS HERE. Read the comment above.
 }
 
@@ -176,14 +179,14 @@ if (host_toolchain == "") {
   # no toolchain omitted host_toolchain from its toolchain_args().
 
   if (host_os == "mac") {
-    host_toolchain = "//build/toolchain/mac:clang_$host_cpu"
+    host_toolchain = "$gn_build_dir/toolchain/mac:clang_$host_cpu"
   } else if (host_os == "win") {
     # On Windows always use the target CPU for host builds. On the
     # configurations we support this will always work and it saves build steps.
     if (is_clang) {
-      host_toolchain = "//build/toolchain/win:clang_$target_cpu"
+      host_toolchain = "$gn_build_dir/toolchain/win:clang_$target_cpu"
     } else {
-      host_toolchain = "//build/toolchain/win:$target_cpu"
+      host_toolchain = "$gn_build_dir/toolchain/win:$target_cpu"
     }
   } else {
     if (target_os != host_os) {
@@ -191,11 +194,11 @@ if (host_toolchain == "") {
       # build, and there is no way to indicate that you want to override
       # it for both the target build *and* the host build. Do we need to
       # support this?
-      host_toolchain = "//build/toolchain/posix:clang_$host_cpu"
+      host_toolchain = "$gn_build_dir/toolchain/posix:clang_$host_cpu"
     } else if (is_clang) {
-      host_toolchain = "//build/toolchain/posix:clang_$host_cpu"
+      host_toolchain = "$gn_build_dir/toolchain/posix:clang_$host_cpu"
     } else {
-      host_toolchain = "//build/toolchain/posix:$host_cpu"
+      host_toolchain = "$gn_build_dir/toolchain/posix:$host_cpu"
     }
   }
 }
@@ -204,12 +207,12 @@ _default_toolchain = ""
 
 if (target_os == "android") {
   if (is_clang) {
-    _default_toolchain = "//build/toolchain/android:android_clang_$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/android:android_clang_$target_cpu"
   } else {
-    _default_toolchain = "//build/toolchain/android:android_$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/android:android_$target_cpu"
   }
 } else if (target_os == "ios") {
-  _default_toolchain = "//build/toolchain/mac:ios_clang_$target_cpu"
+  _default_toolchain = "$gn_build_dir/toolchain/mac:ios_clang_$target_cpu"
 } else if (target_os == "mac") {
   assert(host_os == "mac", "Mac cross-compiles are unsupported.")
   _default_toolchain = host_toolchain
@@ -217,21 +220,21 @@ if (target_os == "android") {
   # On Windows we use the same toolchain for host and target by default.
   assert(target_os == host_os, "Win cross-compiles only work on win hosts.")
   if (is_clang) {
-    _default_toolchain = "//build/toolchain/win:clang_$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/win:clang_$target_cpu"
   } else {
-    _default_toolchain = "//build/toolchain/win:$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/win:$target_cpu"
   }
 } else if (target_os == "winuwp") {
   # Only target WinUWP on for a Windows store application and only
   # x86, x64 and arm are supported target CPUs.
   assert(target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm" ||
          target_cpu == "arm64")
-  _default_toolchain = "//build/toolchain/win:uwp_$target_cpu"
+  _default_toolchain = "$gn_build_dir/toolchain/win:uwp_$target_cpu"
 } else {
   if (is_clang) {
-    _default_toolchain = "//build/toolchain/posix:clang_$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/posix:clang_$target_cpu"
   } else {
-    _default_toolchain = "//build/toolchain/posix:$target_cpu"
+    _default_toolchain = "$gn_build_dir/toolchain/posix:$target_cpu"
   }
 }
 
@@ -319,42 +322,42 @@ if (current_os == "win" || current_os == "winuwp") {
 
 # Holds all configs used for running the compiler.
 default_compiler_configs = [
-  "//build/config:extra_flags",
-  "//build/config:afdo",
-  "//build/config:compiler",
-  "//build/config:pthread",
-  "//build/config:stackrealign",
-  "//build/config:compiler_arm_fpu",
-  "//build/config:compiler_arm_thumb",
-  "//build/config:default_optimization",
-  "//build/config:default_stack_frames",
-  "//build/config:default_symbols",
-  "//build/config:c++11",
-  "//build/config:rtti",
-  "//build/config:exceptions",
-  "//build/config:runtime_library",
-  "//build/config:symbol_visibility_hidden",
+  "$gn_build_dir/config:extra_flags",
+  "$gn_build_dir/config:afdo",
+  "$gn_build_dir/config:compiler",
+  "$gn_build_dir/config:pthread",
+  "$gn_build_dir/config:stackrealign",
+  "$gn_build_dir/config:compiler_arm_fpu",
+  "$gn_build_dir/config:compiler_arm_thumb",
+  "$gn_build_dir/config:default_optimization",
+  "$gn_build_dir/config:default_stack_frames",
+  "$gn_build_dir/config:default_symbols",
+  "$gn_build_dir/config:c++11",
+  "$gn_build_dir/config:rtti",
+  "$gn_build_dir/config:exceptions",
+  "$gn_build_dir/config:runtime_library",
+  "$gn_build_dir/config:symbol_visibility_hidden",
 ]
 if (is_win) {
   default_compiler_configs += [
-    "//build/config/win:default_crt",
-    "//build/config/win:lean_and_mean",
-    "//build/config/win:nominmax",
-    "//build/config/win:winver",
-    "//build/config/win:vs_code_analysis",
+    "$gn_build_dir/config/win:default_crt",
+    "$gn_build_dir/config/win:lean_and_mean",
+    "$gn_build_dir/config/win:nominmax",
+    "$gn_build_dir/config/win:winver",
+    "$gn_build_dir/config/win:vs_code_analysis",
   ]
 }
 
 if (is_android) {
   default_compiler_configs +=
-      [ "//build/config/android:default_cygprofile_instrumentation" ]
+      [ "$gn_build_dir/config/android:default_cygprofile_instrumentation" ]
 }
 
 # Debug/release-related defines.
 if (is_debug) {
-  default_compiler_configs += [ "//build/config:debug" ]
+  default_compiler_configs += [ "$gn_build_dir/config:debug" ]
 } else {
-  default_compiler_configs += [ "//build/config:release" ]
+  default_compiler_configs += [ "$gn_build_dir/config:release" ]
 }
 
 # Static libraries and source sets use only the compiler ones.
@@ -370,24 +373,24 @@ set_defaults("source_set") {
 if (is_win) {
   # Windows linker setup for EXEs and DLLs.
   # Many targets remove these configs, so they are not contained within
-  # //build/config:executable_config for easy removal.
+  # $gn_build_dir/config:executable_config for easy removal.
   _linker_configs = [
-    "//build/config/win:default_incremental_linking",
+    "$gn_build_dir/config/win:default_incremental_linking",
 
     # Default to console-mode apps. Most of our targets are tests and such
     # that shouldn't use the windows subsystem.
-    "//build/config/win:console",
+    "$gn_build_dir/config/win:console",
   ]
 } else if (is_mac || is_ios) {
-  _linker_configs = [ "//build/config/mac:strip_all" ]
+  _linker_configs = [ "$gn_build_dir/config/mac:strip_all" ]
 } else {
   _linker_configs = []
 }
 
 # Executable defaults.
 default_executable_configs = default_compiler_configs + [
-                               "//build/config:default_libs",
-                               "//build/config:executable_config",
+                               "$gn_build_dir/config:default_libs",
+                               "$gn_build_dir/config:executable_config",
                              ] + _linker_configs
 set_defaults("executable") {
   configs = default_executable_configs
@@ -396,8 +399,8 @@ set_defaults("executable") {
 # Shared library and loadable module defaults (also for components in component
 # mode).
 default_shared_library_configs = default_compiler_configs + [
-                                   "//build/config:default_libs",
-                                   "//build/config:shared_library_config",
+                                   "$gn_build_dir/config:default_libs",
+                                   "$gn_build_dir/config:shared_library_config",
                                  ] + _linker_configs
 
 set_defaults("shared_library") {

--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/android/settings.gni")
-import("//build/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/toolchain/android/settings.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
 
 assert(is_android)
 
-# This is included by reference in the //build/config/compiler config that
+# This is included by reference in the $gn_build_dir/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Android-only.
 config("compiler") {
@@ -86,7 +86,7 @@ config("compiler") {
   asmflags = cflags
 }
 
-# This is included by reference in the //build/config:runtime_library
+# This is included by reference in the $gn_build_dir/config:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Android-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.
@@ -202,8 +202,8 @@ config("executable_config") {
 # targets by default. You can override whether the cygprofile instrumentation is
 # used on a per-target basis:
 #
-# configs -= [ "//build/config/android:default_cygprofile_instrumentation" ]
-# configs += [ "//build/config/android:no_cygprofile_instrumentation" ]
+# configs -= [ "$gn_build_dir/config/android:default_cygprofile_instrumentation" ]
+# configs += [ "$gn_build_dir/config/android:no_cygprofile_instrumentation" ]
 
 config("default_cygprofile_instrumentation") {
   if (use_order_profiling) {

--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/android/settings.gni")
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_root/toolchain/android/settings.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
 
 assert(is_android)
 
-# This is included by reference in the $gn_build_dir/config/compiler config that
+# This is included by reference in the $gn_root/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Android-only.
 config("compiler") {
@@ -86,7 +86,7 @@ config("compiler") {
   asmflags = cflags
 }
 
-# This is included by reference in the $gn_build_dir/config:runtime_library
+# This is included by reference in the $gn_root/config:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Android-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.
@@ -202,8 +202,8 @@ config("executable_config") {
 # targets by default. You can override whether the cygprofile instrumentation is
 # used on a per-target basis:
 #
-# configs -= [ "$gn_build_dir/config/android:default_cygprofile_instrumentation" ]
-# configs += [ "$gn_build_dir/config/android:no_cygprofile_instrumentation" ]
+# configs -= [ "$gn_root/config/android:default_cygprofile_instrumentation" ]
+# configs += [ "$gn_root/config/android:no_cygprofile_instrumentation" ]
 
 config("default_cygprofile_instrumentation") {
   if (use_order_profiling) {

--- a/config/compiler.gni
+++ b/config/compiler.gni
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/sanitizers/sanitizers.gni")
-import("//build/config/arm.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/config/arm.gni")
 
 declare_args() {
   # Compile in such a way as to enable profiling of the generated code. For

--- a/config/compiler.gni
+++ b/config/compiler.gni
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
-import("$gn_build_dir/config/arm.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
+import("$gn_root/config/arm.gni")
 
 declare_args() {
   # Compile in such a way as to enable profiling of the generated code. For

--- a/config/ios/BUILD.gn
+++ b/config/ios/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/sysroot.gni")
-import("//build/toolchain/mac/ios_sdk.gni")
+import("$gn_build_dir/toolchain/sysroot.gni")
+import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
 
-# This is included by reference in the //build/config/compiler:runtime_library
+# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is iOS-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/config/ios/BUILD.gn
+++ b/config/ios/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/sysroot.gni")
-import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
+import("$gn_root/toolchain/sysroot.gni")
+import("$gn_root/toolchain/mac/ios_sdk.gni")
 
-# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
+# This is included by reference in the $gn_root/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is iOS-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/config/mac/BUILD.gn
+++ b/config/mac/BUILD.gn
@@ -2,16 +2,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/sysroot.gni")
-import("//build/toolchain/mac/mac_sdk.gni")
+import("$gn_build_dir/toolchain/sysroot.gni")
+import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
 
 if (is_ios) {
   # This needs to be imported after mac_sdk.gni as it overrides some of the
   # variables defined by it.
-  import("//build/toolchain/mac/ios_sdk.gni")
+  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
 }
 
-# This is included by reference in the //build/config/compiler config that
+# This is included by reference in the $gn_build_dir/config/compiler config that
 # is applied to all targets. It is here to separate out the logic.
 #
 # This is applied to BOTH desktop Mac and iOS targets.
@@ -73,7 +73,7 @@ config("compiler") {
   }
 }
 
-# This is included by reference in the //build/config/compiler:runtime_library
+# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Mac-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.
@@ -109,7 +109,7 @@ config("mac_executable_flags") {
 }
 
 # The ldflags referenced below are handled by
-# //build/toolchain/mac/linker_driver.py.
+# $gn_build_dir/toolchain/mac/linker_driver.py.
 # Remove this config if a target wishes to change the arguments passed to the
 # strip command during linking. This config by default strips all symbols
 # from a binary, but some targets may wish to specify a saves file to preserve

--- a/config/mac/BUILD.gn
+++ b/config/mac/BUILD.gn
@@ -2,16 +2,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/sysroot.gni")
-import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
+import("$gn_root/toolchain/sysroot.gni")
+import("$gn_root/toolchain/mac/mac_sdk.gni")
 
 if (is_ios) {
   # This needs to be imported after mac_sdk.gni as it overrides some of the
   # variables defined by it.
-  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
+  import("$gn_root/toolchain/mac/ios_sdk.gni")
 }
 
-# This is included by reference in the $gn_build_dir/config/compiler config that
+# This is included by reference in the $gn_root/config/compiler config that
 # is applied to all targets. It is here to separate out the logic.
 #
 # This is applied to BOTH desktop Mac and iOS targets.
@@ -73,7 +73,7 @@ config("compiler") {
   }
 }
 
-# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
+# This is included by reference in the $gn_root/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Mac-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.
@@ -109,7 +109,7 @@ config("mac_executable_flags") {
 }
 
 # The ldflags referenced below are handled by
-# $gn_build_dir/toolchain/mac/linker_driver.py.
+# $gn_root/toolchain/mac/linker_driver.py.
 # Remove this config if a target wishes to change the arguments passed to the
 # strip command during linking. This config by default strips all symbols
 # from a binary, but some targets may wish to specify a saves file to preserve

--- a/config/posix/BUILD.gn
+++ b/config/posix/BUILD.gn
@@ -1,8 +1,8 @@
-import("$gn_build_dir/toolchain/sysroot.gni")
+import("$gn_root/toolchain/sysroot.gni")
 
 assert(is_posix)
 
-# This is included by reference in the $gn_build_dir/config/compiler config that
+# This is included by reference in the $gn_root/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Posix-only.
 config("compiler") {
@@ -15,7 +15,7 @@ config("compiler") {
   }
 }
 
-# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
+# This is included by reference in the $gn_root/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Posix-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/config/posix/BUILD.gn
+++ b/config/posix/BUILD.gn
@@ -1,8 +1,8 @@
-import("//build/toolchain/sysroot.gni")
+import("$gn_build_dir/toolchain/sysroot.gni")
 
 assert(is_posix)
 
-# This is included by reference in the //build/config/compiler config that
+# This is included by reference in the $gn_build_dir/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Posix-only.
 config("compiler") {
@@ -15,7 +15,7 @@ config("compiler") {
   }
 }
 
-# This is included by reference in the //build/config/compiler:runtime_library
+# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Posix-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/config/win/BUILD.gn
+++ b/config/win/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/config/compiler.gni")
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
-import("$gn_build_dir/toolchain/win/settings.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_root/config/compiler.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
+import("$gn_root/toolchain/win/settings.gni")
+import("$gn_root/toolchain/toolchain.gni")
 
 assert(is_win)
 
@@ -37,7 +37,7 @@ declare_args() {
   win_compiler_timing = false
 }
 
-# This is included by reference in the $gn_build_dir/config/compiler config that
+# This is included by reference in the $gn_root/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Windows-only.
 config("compiler") {
@@ -134,7 +134,7 @@ config("vs_code_analysis") {
   }
 }
 
-# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
+# This is included by reference in the $gn_root/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Windows-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/config/win/BUILD.gn
+++ b/config/win/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/compiler.gni")
-import("//build/config/sanitizers/sanitizers.gni")
-import("//build/toolchain/win/settings.gni")
-import("//build/toolchain/toolchain.gni")
+import("$gn_build_dir/config/compiler.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/toolchain/win/settings.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
 
 assert(is_win)
 
@@ -37,7 +37,7 @@ declare_args() {
   win_compiler_timing = false
 }
 
-# This is included by reference in the //build/config/compiler config that
+# This is included by reference in the $gn_build_dir/config/compiler config that
 # is applied to all targets. It is here to separate out the logic that is
 # Windows-only.
 config("compiler") {
@@ -134,7 +134,7 @@ config("vs_code_analysis") {
   }
 }
 
-# This is included by reference in the //build/config/compiler:runtime_library
+# This is included by reference in the $gn_build_dir/config/compiler:runtime_library
 # config that is applied to all targets. It is here to separate out the logic
 # that is Windows-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.

--- a/gn_helpers_unittest.py
+++ b/gn_helpers_unittest.py
@@ -112,7 +112,7 @@ class UnitTest(unittest.TestCase):
 
     # References to functions should raise an exception.
     with self.assertRaises(gn_helpers.GNException):
-      gn_helpers.FromGNArgs('foo = exec_script("$gn_build_dir/baz.py")')
+      gn_helpers.FromGNArgs('foo = exec_script("$gn_root/baz.py")')
 
     # Underscores in identifiers should work.
     self.assertEqual(gn_helpers.FromGNArgs('_foo = true'),

--- a/gn_helpers_unittest.py
+++ b/gn_helpers_unittest.py
@@ -112,7 +112,7 @@ class UnitTest(unittest.TestCase):
 
     # References to functions should raise an exception.
     with self.assertRaises(gn_helpers.GNException):
-      gn_helpers.FromGNArgs('foo = exec_script("//build/baz.py")')
+      gn_helpers.FromGNArgs('foo = exec_script("$gn_build_dir/baz.py")')
 
     # Underscores in identifiers should work.
     self.assertEqual(gn_helpers.FromGNArgs('_foo = true'),

--- a/toolchain/BUILD.gn
+++ b/toolchain/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/concurrent_links.gni")
+import("$gn_build_dir/toolchain/concurrent_links.gni")
 
 declare_args() {
   # Pool for action tasks.

--- a/toolchain/BUILD.gn
+++ b/toolchain/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/concurrent_links.gni")
+import("$gn_root/toolchain/concurrent_links.gni")
 
 declare_args() {
   # Pool for action tasks.

--- a/toolchain/android/BUILD.gn
+++ b/toolchain/android/BUILD.gn
@@ -2,11 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/android/settings.gni")
-import("//build/toolchain/toolchain.gni")
-import("//build/toolchain/sysroot.gni")
-import("//build/toolchain/gcc_toolchain.gni")
-import("//build/toolchain/clang.gni")
+import("$gn_build_dir/toolchain/android/settings.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_build_dir/toolchain/sysroot.gni")
+import("$gn_build_dir/toolchain/gcc_toolchain.gni")
+import("$gn_build_dir/toolchain/clang.gni")
 
 # The Android GCC toolchains share most of the same parameters, so we have this
 # wrapper around gcc_toolchain to avoid duplication of logic.

--- a/toolchain/android/BUILD.gn
+++ b/toolchain/android/BUILD.gn
@@ -2,11 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/android/settings.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
-import("$gn_build_dir/toolchain/sysroot.gni")
-import("$gn_build_dir/toolchain/gcc_toolchain.gni")
-import("$gn_build_dir/toolchain/clang.gni")
+import("$gn_root/toolchain/android/settings.gni")
+import("$gn_root/toolchain/toolchain.gni")
+import("$gn_root/toolchain/sysroot.gni")
+import("$gn_root/toolchain/gcc_toolchain.gni")
+import("$gn_root/toolchain/clang.gni")
 
 # The Android GCC toolchains share most of the same parameters, so we have this
 # wrapper around gcc_toolchain to avoid duplication of logic.

--- a/toolchain/android/settings.gni
+++ b/toolchain/android/settings.gni
@@ -149,7 +149,7 @@ android_libcpp_root = "$android_ndk_root/sources/cxx-stl/llvm-libc++"
 if (current_cpu == "x86") {
   android_app_abi = "x86"
 } else if (current_cpu == "arm") {
-  import("$gn_build_dir/config/arm.gni")
+  import("$gn_root/config/arm.gni")
   if (arm_version < 7) {
     android_app_abi = "armeabi"
   } else {
@@ -197,9 +197,9 @@ if (target_cpu == "arm64") {
 if (defined(android_secondary_abi_cpu)) {
   if (is_clang) {
     android_secondary_abi_toolchain =
-        "$gn_build_dir/toolchain/android:android_clang_${android_secondary_abi_cpu}"
+        "$gn_root/toolchain/android:android_clang_${android_secondary_abi_cpu}"
   } else {
     android_secondary_abi_toolchain =
-        "$gn_build_dir/toolchain/android:android_${android_secondary_abi_cpu}"
+        "$gn_root/toolchain/android:android_${android_secondary_abi_cpu}"
   }
 }

--- a/toolchain/android/settings.gni
+++ b/toolchain/android/settings.gni
@@ -149,7 +149,7 @@ android_libcpp_root = "$android_ndk_root/sources/cxx-stl/llvm-libc++"
 if (current_cpu == "x86") {
   android_app_abi = "x86"
 } else if (current_cpu == "arm") {
-  import("//build/config/arm.gni")
+  import("$gn_build_dir/config/arm.gni")
   if (arm_version < 7) {
     android_app_abi = "armeabi"
   } else {
@@ -197,9 +197,9 @@ if (target_cpu == "arm64") {
 if (defined(android_secondary_abi_cpu)) {
   if (is_clang) {
     android_secondary_abi_toolchain =
-        "//build/toolchain/android:android_clang_${android_secondary_abi_cpu}"
+        "$gn_build_dir/toolchain/android:android_clang_${android_secondary_abi_cpu}"
   } else {
     android_secondary_abi_toolchain =
-        "//build/toolchain/android:android_${android_secondary_abi_cpu}"
+        "$gn_build_dir/toolchain/android:android_${android_secondary_abi_cpu}"
   }
 }

--- a/toolchain/compiler_version.gni
+++ b/toolchain/compiler_version.gni
@@ -2,13 +2,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/toolchain.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
 
 # Bring all the windows toolchain definitions in.
 # Officially msc_ver etc. live here, but they're actually defined
 # in win/settings.gni.
 if (is_win) {
-  import("//build/toolchain/win/settings.gni")
+  import("$gn_build_dir/toolchain/win/settings.gni")
 }
 
 # Defines compiler versions for compilers used by multiple toolchains.
@@ -32,11 +32,11 @@ declare_args() {
 
 if (gcc_version == 0 && !is_clang && !is_win) {
   if (is_android) {
-    # sync with //build/toolchain/android/BUILD.gn
-    import("//build/toolchain/android/settings.gni")
+    # sync with $gn_build_dir/toolchain/android/BUILD.gn
+    import("$gn_build_dir/toolchain/android/settings.gni")
     _exe = "${android_tool_prefix}gcc"
   } else if (is_posix) {
-    import("//build/toolchain/posix/settings.gni")
+    import("$gn_build_dir/toolchain/posix/settings.gni")
     _exe = gcc_cc
   } else {
     assert(false, "GCC isn't supported on this platform")
@@ -51,11 +51,11 @@ if (gcc_version == 0 && !is_clang && !is_win) {
 
 if (clang_version == 0 && is_clang && !is_win) {
   if (is_android) {
-    # sync with //build/toolchain/android/BUILD.gn
-    import("//build/toolchain/clang.gni")
+    # sync with $gn_build_dir/toolchain/android/BUILD.gn
+    import("$gn_build_dir/toolchain/clang.gni")
     _exe = "$clang_base_path/bin/clang"
   } else if (is_posix) {
-    import("//build/toolchain/posix/settings.gni")
+    import("$gn_build_dir/toolchain/posix/settings.gni")
     _exe = clang_cc
   } else {
     assert(false, "GCC isn't supported on this platform")

--- a/toolchain/compiler_version.gni
+++ b/toolchain/compiler_version.gni
@@ -2,13 +2,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_root/toolchain/toolchain.gni")
 
 # Bring all the windows toolchain definitions in.
 # Officially msc_ver etc. live here, but they're actually defined
 # in win/settings.gni.
 if (is_win) {
-  import("$gn_build_dir/toolchain/win/settings.gni")
+  import("$gn_root/toolchain/win/settings.gni")
 }
 
 # Defines compiler versions for compilers used by multiple toolchains.
@@ -32,11 +32,11 @@ declare_args() {
 
 if (gcc_version == 0 && !is_clang && !is_win) {
   if (is_android) {
-    # sync with $gn_build_dir/toolchain/android/BUILD.gn
-    import("$gn_build_dir/toolchain/android/settings.gni")
+    # sync with $gn_root/toolchain/android/BUILD.gn
+    import("$gn_root/toolchain/android/settings.gni")
     _exe = "${android_tool_prefix}gcc"
   } else if (is_posix) {
-    import("$gn_build_dir/toolchain/posix/settings.gni")
+    import("$gn_root/toolchain/posix/settings.gni")
     _exe = gcc_cc
   } else {
     assert(false, "GCC isn't supported on this platform")
@@ -51,11 +51,11 @@ if (gcc_version == 0 && !is_clang && !is_win) {
 
 if (clang_version == 0 && is_clang && !is_win) {
   if (is_android) {
-    # sync with $gn_build_dir/toolchain/android/BUILD.gn
-    import("$gn_build_dir/toolchain/clang.gni")
+    # sync with $gn_root/toolchain/android/BUILD.gn
+    import("$gn_root/toolchain/clang.gni")
     _exe = "$clang_base_path/bin/clang"
   } else if (is_posix) {
-    import("$gn_build_dir/toolchain/posix/settings.gni")
+    import("$gn_root/toolchain/posix/settings.gni")
     _exe = clang_cc
   } else {
     assert(false, "GCC isn't supported on this platform")

--- a/toolchain/gcc_toolchain.gni
+++ b/toolchain/gcc_toolchain.gni
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/sanitizers/sanitizers.gni")
-import("//build/toolchain/cc_wrapper.gni")
-import("//build/toolchain/toolchain.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/toolchain/cc_wrapper.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
 
 # This template defines a toolchain for something that works like gcc
 # (including clang).
@@ -245,7 +245,7 @@ template("gcc_toolchain") {
       # command, in case the host does not use a POSIX shell (e.g. compiling
       # POSIX-like toolchains such as NaCl on Windows).
       ar_wrapper =
-          rebase_path("//build/toolchain/gcc_ar_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/gcc_ar_wrapper.py", root_build_dir)
 
       # BSD ar doesn't support response files
       if (!is_freebsd || nm != "nm") {
@@ -272,7 +272,7 @@ template("gcc_toolchain") {
       soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
       sofile = "{{output_dir}}/$soname"  # Possibly including toolchain dir.
       rspfile = sofile + ".rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       if (defined(invoker.strip)) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
@@ -307,7 +307,7 @@ template("gcc_toolchain") {
       # This needs a Python script to avoid using a complex shell command
       # requiring sh control structures, pipelines, and POSIX utilities.
       # The host might not have a POSIX shell and utilities (e.g. Windows).
-      solink_wrapper = rebase_path("//build/toolchain/gcc_solink_wrapper.py")
+      solink_wrapper = rebase_path("$gn_build_dir/toolchain/gcc_solink_wrapper.py")
       command = "$python_path \"$solink_wrapper\" --readelf=\"$readelf\" --nm=\"$nm\" $strip_switch--sofile=\"$unstripped_sofile\" --tocfile=\"$tocfile\"$map_switch --output=\"$sofile\" -- $link_command"
 
       rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix"
@@ -348,7 +348,7 @@ template("gcc_toolchain") {
       soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
       sofile = "{{output_dir}}/$soname"
       rspfile = sofile + ".rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       if (defined(invoker.strip)) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
@@ -392,7 +392,7 @@ template("gcc_toolchain") {
       outfile = "{{output_dir}}/$exename"
       rspfile = "$outfile.rsp"
       unstripped_outfile = outfile
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       # Use this for {{output_extension}} expansions unless a target manually
       # overrides it (in which case {{output_extension}} will be what the target
@@ -422,7 +422,7 @@ template("gcc_toolchain") {
       }
 
       link_wrapper =
-          rebase_path("//build/toolchain/gcc_link_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/gcc_link_wrapper.py", root_build_dir)
       command = "$python_path \"$link_wrapper\" --output=\"$outfile\"$strip_switch$map_switch -- $link_command"
       description = "LINK $outfile"
       rspfile_content = "{{inputs}}"
@@ -442,7 +442,7 @@ template("gcc_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See //build/toolchain/toolchain.gni for details.
+    # See $gn_build_dir/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
@@ -453,7 +453,7 @@ template("gcc_toolchain") {
     }
 
     tool("action") {
-      pool = "//build/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
     }
 
     forward_variables_from(invoker, [ "deps" ])

--- a/toolchain/gcc_toolchain.gni
+++ b/toolchain/gcc_toolchain.gni
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
-import("$gn_build_dir/toolchain/cc_wrapper.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
+import("$gn_root/toolchain/cc_wrapper.gni")
+import("$gn_root/toolchain/toolchain.gni")
 
 # This template defines a toolchain for something that works like gcc
 # (including clang).
@@ -245,7 +245,7 @@ template("gcc_toolchain") {
       # command, in case the host does not use a POSIX shell (e.g. compiling
       # POSIX-like toolchains such as NaCl on Windows).
       ar_wrapper =
-          rebase_path("$gn_build_dir/toolchain/gcc_ar_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/gcc_ar_wrapper.py", root_build_dir)
 
       # BSD ar doesn't support response files
       if (!is_freebsd || nm != "nm") {
@@ -272,7 +272,7 @@ template("gcc_toolchain") {
       soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
       sofile = "{{output_dir}}/$soname"  # Possibly including toolchain dir.
       rspfile = sofile + ".rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       if (defined(invoker.strip)) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
@@ -307,7 +307,7 @@ template("gcc_toolchain") {
       # This needs a Python script to avoid using a complex shell command
       # requiring sh control structures, pipelines, and POSIX utilities.
       # The host might not have a POSIX shell and utilities (e.g. Windows).
-      solink_wrapper = rebase_path("$gn_build_dir/toolchain/gcc_solink_wrapper.py")
+      solink_wrapper = rebase_path("$gn_root/toolchain/gcc_solink_wrapper.py")
       command = "$python_path \"$solink_wrapper\" --readelf=\"$readelf\" --nm=\"$nm\" $strip_switch--sofile=\"$unstripped_sofile\" --tocfile=\"$tocfile\"$map_switch --output=\"$sofile\" -- $link_command"
 
       rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix"
@@ -348,7 +348,7 @@ template("gcc_toolchain") {
       soname = "{{target_output_name}}{{output_extension}}"  # e.g. "libfoo.so".
       sofile = "{{output_dir}}/$soname"
       rspfile = sofile + ".rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       if (defined(invoker.strip)) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
@@ -392,7 +392,7 @@ template("gcc_toolchain") {
       outfile = "{{output_dir}}/$exename"
       rspfile = "$outfile.rsp"
       unstripped_outfile = outfile
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       # Use this for {{output_extension}} expansions unless a target manually
       # overrides it (in which case {{output_extension}} will be what the target
@@ -422,7 +422,7 @@ template("gcc_toolchain") {
       }
 
       link_wrapper =
-          rebase_path("$gn_build_dir/toolchain/gcc_link_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/gcc_link_wrapper.py", root_build_dir)
       command = "$python_path \"$link_wrapper\" --output=\"$outfile\"$strip_switch$map_switch -- $link_command"
       description = "LINK $outfile"
       rspfile_content = "{{inputs}}"
@@ -442,7 +442,7 @@ template("gcc_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See $gn_build_dir/toolchain/toolchain.gni for details.
+    # See $gn_root/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
@@ -453,7 +453,7 @@ template("gcc_toolchain") {
     }
 
     tool("action") {
-      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:action_pool($default_toolchain)"
     }
 
     forward_variables_from(invoker, [ "deps" ])

--- a/toolchain/mac/BUILD.gn
+++ b/toolchain/mac/BUILD.gn
@@ -6,17 +6,17 @@
 # some enhancements since the commands on Mac are slightly different than on
 # Linux.
 
-import("$gn_build_dir/toolchain/clang.gni")
+import("$gn_root/toolchain/clang.gni")
 if (is_ios) {
-  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
+  import("$gn_root/toolchain/mac/ios_sdk.gni")
 }
-import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
+import("$gn_root/toolchain/mac/mac_sdk.gni")
 
 assert(host_os == "mac")
 
-import("$gn_build_dir/toolchain/cc_wrapper.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
-import("$gn_build_dir/toolchain/concurrent_links.gni")
+import("$gn_root/toolchain/cc_wrapper.gni")
+import("$gn_root/toolchain/toolchain.gni")
+import("$gn_root/toolchain/concurrent_links.gni")
 
 declare_args() {
   # Reduce the number of tasks using the copy_bundle_data and compile_xcassets
@@ -48,9 +48,9 @@ if (current_toolchain == default_toolchain) {
 tool_versions =
     exec_script("get_tool_mtime.py",
                 rebase_path([
-                              "$gn_build_dir/toolchain/mac/compile_xcassets.py",
-                              "$gn_build_dir/toolchain/mac/filter_libtool.py",
-                              "$gn_build_dir/toolchain/mac/linker_driver.py",
+                              "$gn_root/toolchain/mac/compile_xcassets.py",
+                              "$gn_root/toolchain/mac/filter_libtool.py",
+                              "$gn_root/toolchain/mac/linker_driver.py",
                             ],
                             root_build_dir),
                 "trim scope")
@@ -108,7 +108,7 @@ template("mac_toolchain") {
 
     linker_driver =
         "TOOL_VERSION=${tool_versions.linker_driver} " +
-        rebase_path("$gn_build_dir/toolchain/mac/linker_driver.py", root_build_dir)
+        rebase_path("$gn_root/toolchain/mac/linker_driver.py", root_build_dir)
 
     # On iOS, the final applications are assembled using lipo (to support fat
     # builds). The correct flags are passed to the linker_driver.py script
@@ -206,7 +206,7 @@ template("mac_toolchain") {
 
     tool("alink") {
       script =
-          rebase_path("$gn_build_dir/toolchain/mac/filter_libtool.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/mac/filter_libtool.py", root_build_dir)
       command = "$env_wrapper rm -f {{output}} && TOOL_VERSION=${tool_versions.filter_libtool} python $script libtool -static {{arflags}} -o {{output}} {{inputs}}"
       description = "LIBTOOL-STATIC {{output}}"
       outputs = [
@@ -220,7 +220,7 @@ template("mac_toolchain") {
     tool("solink") {
       dylib = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # eg "./libfoo.dylib"
       rspfile = dylib + ".rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       # These variables are not built into GN but are helpers that implement
       # (1) linking to produce a .dylib, (2) extracting the symbols from that
@@ -280,7 +280,7 @@ template("mac_toolchain") {
     tool("solink_module") {
       sofile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # eg "./libfoo.so"
       rspfile = sofile + ".rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       link_command = "$env_wrapper $linker_driver $ld -bundle {{ldflags}} -o \"$sofile\" -Wl,-filelist,\"$rspfile\""
       link_command += dsym_switch + " {{solibs}} {{libs}}"
@@ -311,7 +311,7 @@ template("mac_toolchain") {
     tool("link") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       rspfile = "$outfile.rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       # Note about --filelist: Apple's linker reads the file list file and
       # interprets each newline-separated chunk of text as a file name. It
@@ -340,7 +340,7 @@ template("mac_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See $gn_build_dir/toolchain/toolchain.gni for details.
+    # See $gn_root/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
@@ -379,7 +379,7 @@ template("mac_toolchain") {
     }
 
     tool("compile_xcassets") {
-      _tool = rebase_path("$gn_build_dir/toolchain/mac/compile_xcassets.py",
+      _tool = rebase_path("$gn_root/toolchain/mac/compile_xcassets.py",
                           root_build_dir)
       if (is_ios) {
         _sdk_name = ios_sdk_name
@@ -398,7 +398,7 @@ template("mac_toolchain") {
     }
 
     tool("action") {
-      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:action_pool($default_toolchain)"
     }
   }
 }

--- a/toolchain/mac/BUILD.gn
+++ b/toolchain/mac/BUILD.gn
@@ -6,17 +6,17 @@
 # some enhancements since the commands on Mac are slightly different than on
 # Linux.
 
-import("//build/toolchain/clang.gni")
+import("$gn_build_dir/toolchain/clang.gni")
 if (is_ios) {
-  import("//build/toolchain/mac/ios_sdk.gni")
+  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
 }
-import("//build/toolchain/mac/mac_sdk.gni")
+import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
 
 assert(host_os == "mac")
 
-import("//build/toolchain/cc_wrapper.gni")
-import("//build/toolchain/toolchain.gni")
-import("//build/toolchain/concurrent_links.gni")
+import("$gn_build_dir/toolchain/cc_wrapper.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_build_dir/toolchain/concurrent_links.gni")
 
 declare_args() {
   # Reduce the number of tasks using the copy_bundle_data and compile_xcassets
@@ -48,9 +48,9 @@ if (current_toolchain == default_toolchain) {
 tool_versions =
     exec_script("get_tool_mtime.py",
                 rebase_path([
-                              "//build/toolchain/mac/compile_xcassets.py",
-                              "//build/toolchain/mac/filter_libtool.py",
-                              "//build/toolchain/mac/linker_driver.py",
+                              "$gn_build_dir/toolchain/mac/compile_xcassets.py",
+                              "$gn_build_dir/toolchain/mac/filter_libtool.py",
+                              "$gn_build_dir/toolchain/mac/linker_driver.py",
                             ],
                             root_build_dir),
                 "trim scope")
@@ -108,7 +108,7 @@ template("mac_toolchain") {
 
     linker_driver =
         "TOOL_VERSION=${tool_versions.linker_driver} " +
-        rebase_path("//build/toolchain/mac/linker_driver.py", root_build_dir)
+        rebase_path("$gn_build_dir/toolchain/mac/linker_driver.py", root_build_dir)
 
     # On iOS, the final applications are assembled using lipo (to support fat
     # builds). The correct flags are passed to the linker_driver.py script
@@ -206,7 +206,7 @@ template("mac_toolchain") {
 
     tool("alink") {
       script =
-          rebase_path("//build/toolchain/mac/filter_libtool.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/mac/filter_libtool.py", root_build_dir)
       command = "$env_wrapper rm -f {{output}} && TOOL_VERSION=${tool_versions.filter_libtool} python $script libtool -static {{arflags}} -o {{output}} {{inputs}}"
       description = "LIBTOOL-STATIC {{output}}"
       outputs = [
@@ -220,7 +220,7 @@ template("mac_toolchain") {
     tool("solink") {
       dylib = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # eg "./libfoo.dylib"
       rspfile = dylib + ".rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       # These variables are not built into GN but are helpers that implement
       # (1) linking to produce a .dylib, (2) extracting the symbols from that
@@ -280,7 +280,7 @@ template("mac_toolchain") {
     tool("solink_module") {
       sofile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # eg "./libfoo.so"
       rspfile = sofile + ".rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       link_command = "$env_wrapper $linker_driver $ld -bundle {{ldflags}} -o \"$sofile\" -Wl,-filelist,\"$rspfile\""
       link_command += dsym_switch + " {{solibs}} {{libs}}"
@@ -311,7 +311,7 @@ template("mac_toolchain") {
     tool("link") {
       outfile = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       rspfile = "$outfile.rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       # Note about --filelist: Apple's linker reads the file list file and
       # interprets each newline-separated chunk of text as a file name. It
@@ -340,7 +340,7 @@ template("mac_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See //build/toolchain/toolchain.gni for details.
+    # See $gn_build_dir/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
@@ -379,7 +379,7 @@ template("mac_toolchain") {
     }
 
     tool("compile_xcassets") {
-      _tool = rebase_path("//build/toolchain/mac/compile_xcassets.py",
+      _tool = rebase_path("$gn_build_dir/toolchain/mac/compile_xcassets.py",
                           root_build_dir)
       if (is_ios) {
         _sdk_name = ios_sdk_name
@@ -398,7 +398,7 @@ template("mac_toolchain") {
     }
 
     tool("action") {
-      pool = "//build/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
     }
   }
 }

--- a/toolchain/mac/ios_sdk.gni
+++ b/toolchain/mac/ios_sdk.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/mac/settings.gni")
+import("$gn_build_dir/toolchain/mac/settings.gni")
 
 declare_args() {
   # SDK path to use. When empty this will use the default SDK based on the
@@ -66,7 +66,7 @@ if (additional_target_cpus != []) {
     assert(_additional_target_cpu != target_cpu,
            "target_cpu must not be listed in additional_target_cpus")
 
-    _toolchain = "//build/toolchain/mac:ios_clang_$_additional_target_cpu"
+    _toolchain = "$gn_build_dir/toolchain/mac:ios_clang_$_additional_target_cpu"
     foreach(_additional_toolchain, additional_toolchains) {
       assert(_toolchain != _additional_toolchain,
              "additional_target_cpus must not contains duplicate values")
@@ -94,7 +94,7 @@ if (ios_sdk_path == "") {
     ]
   }
   ios_sdk_info_args += [ ios_sdk_name ]
-  script_name = "//build/toolchain/mac/sdk_info.py"
+  script_name = "$gn_build_dir/toolchain/mac/sdk_info.py"
   _ios_sdk_result = exec_script(script_name, ios_sdk_info_args, "scope")
   ios_sdk_path = _ios_sdk_result.sdk_path
   ios_sdk_version = _ios_sdk_result.sdk_version

--- a/toolchain/mac/ios_sdk.gni
+++ b/toolchain/mac/ios_sdk.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/mac/settings.gni")
+import("$gn_root/toolchain/mac/settings.gni")
 
 declare_args() {
   # SDK path to use. When empty this will use the default SDK based on the
@@ -66,7 +66,7 @@ if (additional_target_cpus != []) {
     assert(_additional_target_cpu != target_cpu,
            "target_cpu must not be listed in additional_target_cpus")
 
-    _toolchain = "$gn_build_dir/toolchain/mac:ios_clang_$_additional_target_cpu"
+    _toolchain = "$gn_root/toolchain/mac:ios_clang_$_additional_target_cpu"
     foreach(_additional_toolchain, additional_toolchains) {
       assert(_toolchain != _additional_toolchain,
              "additional_target_cpus must not contains duplicate values")
@@ -94,7 +94,7 @@ if (ios_sdk_path == "") {
     ]
   }
   ios_sdk_info_args += [ ios_sdk_name ]
-  script_name = "$gn_build_dir/toolchain/mac/sdk_info.py"
+  script_name = "$gn_root/toolchain/mac/sdk_info.py"
   _ios_sdk_result = exec_script(script_name, ios_sdk_info_args, "scope")
   ios_sdk_path = _ios_sdk_result.sdk_path
   ios_sdk_version = _ios_sdk_result.sdk_version

--- a/toolchain/mac/mac_sdk.gni
+++ b/toolchain/mac/mac_sdk.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/mac/settings.gni")
+import("$gn_build_dir/toolchain/mac/settings.gni")
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
@@ -31,7 +31,7 @@ find_sdk_args += [ mac_sdk_min ]
 
 # The tool will print the SDK path on the first line, and the version on the
 # second line.
-find_sdk_lines = exec_script("//build/toolchain/mac/find_sdk.py",
+find_sdk_lines = exec_script("$gn_build_dir/toolchain/mac/find_sdk.py",
                              find_sdk_args,
                              "list lines")
 mac_sdk_version = find_sdk_lines[1]
@@ -39,7 +39,7 @@ if (mac_sdk_path == "") {
   mac_sdk_path = find_sdk_lines[0]
 }
 
-script_name = "//build/toolchain/mac/sdk_info.py"
+script_name = "$gn_build_dir/toolchain/mac/sdk_info.py"
 sdk_info_args = []
 if (!use_system_xcode) {
   sdk_info_args += [

--- a/toolchain/mac/mac_sdk.gni
+++ b/toolchain/mac/mac_sdk.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/toolchain/mac/settings.gni")
+import("$gn_root/toolchain/mac/settings.gni")
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
@@ -31,7 +31,7 @@ find_sdk_args += [ mac_sdk_min ]
 
 # The tool will print the SDK path on the first line, and the version on the
 # second line.
-find_sdk_lines = exec_script("$gn_build_dir/toolchain/mac/find_sdk.py",
+find_sdk_lines = exec_script("$gn_root/toolchain/mac/find_sdk.py",
                              find_sdk_args,
                              "list lines")
 mac_sdk_version = find_sdk_lines[1]
@@ -39,7 +39,7 @@ if (mac_sdk_path == "") {
   mac_sdk_path = find_sdk_lines[0]
 }
 
-script_name = "$gn_build_dir/toolchain/mac/sdk_info.py"
+script_name = "$gn_root/toolchain/mac/sdk_info.py"
 sdk_info_args = []
 if (!use_system_xcode) {
   sdk_info_args += [

--- a/toolchain/mac/settings.gni
+++ b/toolchain/mac/settings.gni
@@ -19,16 +19,16 @@ declare_args() {
 
   # Produce dSYM files for targets that are configured to do so. dSYM
   # generation is controlled globally as it is a linker output (produced via
-  # the //build/toolchain/mac/linker_driver.py. Enabling this will result in
+  # the $gn_build_dir/toolchain/mac/linker_driver.py. Enabling this will result in
   # all shared library, loadable module, and executable targets having a dSYM
   # generated.
   enable_dsyms = true
 
   # Strip symbols from linked targets by default. If this is enabled, the
-  # //build/config/mac:strip_all config will be applied to all linked targets.
+  # $gn_build_dir/config/mac:strip_all config will be applied to all linked targets.
   # If custom stripping parameters are required, remove that config from a
   # linked target and apply custom -Wcrl,strip flags. See
-  # //build/toolchain/mac/linker_driver.py for more information.
+  # $gn_build_dir/toolchain/mac/linker_driver.py for more information.
   enable_stripping = is_official_build
 }
 

--- a/toolchain/mac/settings.gni
+++ b/toolchain/mac/settings.gni
@@ -19,16 +19,16 @@ declare_args() {
 
   # Produce dSYM files for targets that are configured to do so. dSYM
   # generation is controlled globally as it is a linker output (produced via
-  # the $gn_build_dir/toolchain/mac/linker_driver.py. Enabling this will result in
+  # the $gn_root/toolchain/mac/linker_driver.py. Enabling this will result in
   # all shared library, loadable module, and executable targets having a dSYM
   # generated.
   enable_dsyms = true
 
   # Strip symbols from linked targets by default. If this is enabled, the
-  # $gn_build_dir/config/mac:strip_all config will be applied to all linked targets.
+  # $gn_root/config/mac:strip_all config will be applied to all linked targets.
   # If custom stripping parameters are required, remove that config from a
   # linked target and apply custom -Wcrl,strip flags. See
-  # $gn_build_dir/toolchain/mac/linker_driver.py for more information.
+  # $gn_root/toolchain/mac/linker_driver.py for more information.
   enable_stripping = is_official_build
 }
 

--- a/toolchain/posix/BUILD.gn
+++ b/toolchain/posix/BUILD.gn
@@ -1,5 +1,5 @@
-import("//build/toolchain/gcc_toolchain.gni")
-import("//build/toolchain/posix/settings.gni")
+import("$gn_build_dir/toolchain/gcc_toolchain.gni")
+import("$gn_build_dir/toolchain/posix/settings.gni")
 
 gcc_toolchain("clang_x86") {
   cc = clang_cc

--- a/toolchain/posix/BUILD.gn
+++ b/toolchain/posix/BUILD.gn
@@ -1,5 +1,5 @@
-import("$gn_build_dir/toolchain/gcc_toolchain.gni")
-import("$gn_build_dir/toolchain/posix/settings.gni")
+import("$gn_root/toolchain/gcc_toolchain.gni")
+import("$gn_root/toolchain/posix/settings.gni")
 
 gcc_toolchain("clang_x86") {
   cc = clang_cc

--- a/toolchain/posix/settings.gni
+++ b/toolchain/posix/settings.gni
@@ -1,5 +1,5 @@
 if (is_clang) {
-  import("//build/toolchain/clang.gni")
+  import("$gn_build_dir/toolchain/clang.gni")
 }
 
 declare_args() {

--- a/toolchain/posix/settings.gni
+++ b/toolchain/posix/settings.gni
@@ -1,5 +1,5 @@
 if (is_clang) {
-  import("$gn_build_dir/toolchain/clang.gni")
+  import("$gn_root/toolchain/clang.gni")
 }
 
 declare_args() {

--- a/toolchain/sysroot.gni
+++ b/toolchain/sysroot.gni
@@ -17,7 +17,7 @@ if (current_os == target_os && current_cpu == target_cpu &&
     target_sysroot != "") {
   sysroot = target_sysroot
 } else if (is_android) {
-  import("//build/toolchain/android/settings.gni")
+  import("$gn_build_dir/toolchain/android/settings.gni")
   if (current_cpu == "x86") {
     sysroot = "$android_ndk_root/$x86_android_sysroot_subdir"
   } else if (current_cpu == "arm") {
@@ -34,10 +34,10 @@ if (current_os == target_os && current_cpu == target_cpu &&
     sysroot = ""
   }
 } else if (is_mac) {
-  import("//build/toolchain/mac/mac_sdk.gni")
+  import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
   sysroot = mac_sdk_path
 } else if (is_ios) {
-  import("//build/toolchain/mac/ios_sdk.gni")
+  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
   sysroot = ios_sdk_path
 } else {
   sysroot = ""

--- a/toolchain/sysroot.gni
+++ b/toolchain/sysroot.gni
@@ -17,7 +17,7 @@ if (current_os == target_os && current_cpu == target_cpu &&
     target_sysroot != "") {
   sysroot = target_sysroot
 } else if (is_android) {
-  import("$gn_build_dir/toolchain/android/settings.gni")
+  import("$gn_root/toolchain/android/settings.gni")
   if (current_cpu == "x86") {
     sysroot = "$android_ndk_root/$x86_android_sysroot_subdir"
   } else if (current_cpu == "arm") {
@@ -34,10 +34,10 @@ if (current_os == target_os && current_cpu == target_cpu &&
     sysroot = ""
   }
 } else if (is_mac) {
-  import("$gn_build_dir/toolchain/mac/mac_sdk.gni")
+  import("$gn_root/toolchain/mac/mac_sdk.gni")
   sysroot = mac_sdk_path
 } else if (is_ios) {
-  import("$gn_build_dir/toolchain/mac/ios_sdk.gni")
+  import("$gn_root/toolchain/mac/ios_sdk.gni")
   sysroot = ios_sdk_path
 } else {
   sysroot = ""

--- a/toolchain/toolchain.gni
+++ b/toolchain/toolchain.gni
@@ -44,9 +44,9 @@ if (is_posix) {
 stamp_description = "STAMP {{output}}"
 copy_description = "COPY {{source}} {{output}}"
 if (host_os == "win") {
-  stamp_path = rebase_path("$gn_build_dir/toolchain/win/stamp.py", root_build_dir)
+  stamp_path = rebase_path("$gn_root/toolchain/win/stamp.py", root_build_dir)
   copy_path =
-      rebase_path("$gn_build_dir/toolchain/win/recursive_mirror.py", root_build_dir)
+      rebase_path("$gn_root/toolchain/win/recursive_mirror.py", root_build_dir)
 
   stamp_command = "cmd /c type nul > \"{{output}}\""
   copy_command = "$python_path $copy_path {{source}} {{output}}"

--- a/toolchain/toolchain.gni
+++ b/toolchain/toolchain.gni
@@ -44,9 +44,9 @@ if (is_posix) {
 stamp_description = "STAMP {{output}}"
 copy_description = "COPY {{source}} {{output}}"
 if (host_os == "win") {
-  stamp_path = rebase_path("//build/toolchain/win/stamp.py", root_build_dir)
+  stamp_path = rebase_path("$gn_build_dir/toolchain/win/stamp.py", root_build_dir)
   copy_path =
-      rebase_path("//build/toolchain/win/recursive_mirror.py", root_build_dir)
+      rebase_path("$gn_build_dir/toolchain/win/recursive_mirror.py", root_build_dir)
 
   stamp_command = "cmd /c type nul > \"{{output}}\""
   copy_command = "$python_path $copy_path {{source}} {{output}}"

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -2,11 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/sanitizers/sanitizers.gni")
-import("//build/toolchain/win/settings.gni")
-import("//build/toolchain/clang_static_analyzer.gni")
-import("//build/toolchain/toolchain.gni")
-import("//build/toolchain/clang.gni")
+import("$gn_build_dir/config/sanitizers/sanitizers.gni")
+import("$gn_build_dir/toolchain/win/settings.gni")
+import("$gn_build_dir/toolchain/clang_static_analyzer.gni")
+import("$gn_build_dir/toolchain/toolchain.gni")
+import("$gn_build_dir/toolchain/clang.gni")
 
 # Should only be running on Windows.
 assert(is_win)
@@ -83,7 +83,7 @@ template("msvc_toolchain") {
     if (toolchain_uses_clang && use_clang_static_analyzer) {
       analyzer_prefix =
           "$python_path " +
-          rebase_path("//build/toolchain/clang_static_analyzer_wrapper.py",
+          rebase_path("$gn_build_dir/toolchain/clang_static_analyzer_wrapper.py",
                       root_build_dir) + " --mode=cl"
       cl = "${analyzer_prefix} ${cl}"
     }
@@ -154,7 +154,7 @@ template("msvc_toolchain") {
 
     tool("rc") {
       rc_wrapper =
-          rebase_path("//build/toolchain/win/rc_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/rc_wrapper.py", root_build_dir)
       command = "$python_path $rc_wrapper $env {{source}} {{output}} rc.exe {{defines}} {{include_dirs}}"
       depsformat = "msvc"
       outputs = [
@@ -170,7 +170,7 @@ template("msvc_toolchain") {
         ml = "ml.exe"
       }
       asm_wrapper =
-          rebase_path("//build/toolchain/win/asm_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/asm_wrapper.py", root_build_dir)
       command = "$python_path $asm_wrapper $env $ml {{defines}} {{include_dirs}} {{asmflags}} /c /Fo{{output}} {{source}}"
       description = "ASM {{output}}"
       outputs = [
@@ -182,7 +182,7 @@ template("msvc_toolchain") {
       rspfile = "{{output}}.rsp"
 
       link_wrapper =
-          rebase_path("//build/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $lib /nologo {{arflags}} /OUT:{{output}} @$rspfile"
       description = "LIB {{output}}"
       outputs = [
@@ -203,10 +203,10 @@ template("msvc_toolchain") {
       libname = "${dllname}.lib"  # e.g. foo.dll.lib
       pdbname = "${dllname}.pdb"
       rspfile = "${dllname}.rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("//build/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /IMPLIB:$libname /DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
 
       default_output_extension = ".dll"
@@ -238,10 +238,10 @@ template("msvc_toolchain") {
       dllname = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # e.g. foo.dll
       pdbname = "${dllname}.pdb"
       rspfile = "${dllname}.rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("//build/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
 
       default_output_extension = ".dll"
@@ -264,10 +264,10 @@ template("msvc_toolchain") {
       exename = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       pdbname = "$exename.pdb"
       rspfile = "$exename.rsp"
-      pool = "//build/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("//build/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /OUT:$exename /PDB:$pdbname @$rspfile"
 
       if (linkrepro_root_dir != "") {
@@ -298,20 +298,20 @@ template("msvc_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See //build/toolchain/toolchain.gni for details.
+    # See $gn_build_dir/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
-      pool = "//build/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
     }
     tool("copy") {
       command = copy_command
       description = copy_description
-      pool = "//build/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
     }
 
     tool("action") {
-      pool = "//build/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
     }
   }
 }

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -2,11 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$gn_build_dir/config/sanitizers/sanitizers.gni")
-import("$gn_build_dir/toolchain/win/settings.gni")
-import("$gn_build_dir/toolchain/clang_static_analyzer.gni")
-import("$gn_build_dir/toolchain/toolchain.gni")
-import("$gn_build_dir/toolchain/clang.gni")
+import("$gn_root/config/sanitizers/sanitizers.gni")
+import("$gn_root/toolchain/win/settings.gni")
+import("$gn_root/toolchain/clang_static_analyzer.gni")
+import("$gn_root/toolchain/toolchain.gni")
+import("$gn_root/toolchain/clang.gni")
 
 # Should only be running on Windows.
 assert(is_win)
@@ -83,7 +83,7 @@ template("msvc_toolchain") {
     if (toolchain_uses_clang && use_clang_static_analyzer) {
       analyzer_prefix =
           "$python_path " +
-          rebase_path("$gn_build_dir/toolchain/clang_static_analyzer_wrapper.py",
+          rebase_path("$gn_root/toolchain/clang_static_analyzer_wrapper.py",
                       root_build_dir) + " --mode=cl"
       cl = "${analyzer_prefix} ${cl}"
     }
@@ -154,7 +154,7 @@ template("msvc_toolchain") {
 
     tool("rc") {
       rc_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/rc_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/rc_wrapper.py", root_build_dir)
       command = "$python_path $rc_wrapper $env {{source}} {{output}} rc.exe {{defines}} {{include_dirs}}"
       depsformat = "msvc"
       outputs = [
@@ -170,7 +170,7 @@ template("msvc_toolchain") {
         ml = "ml.exe"
       }
       asm_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/asm_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/asm_wrapper.py", root_build_dir)
       command = "$python_path $asm_wrapper $env $ml {{defines}} {{include_dirs}} {{asmflags}} /c /Fo{{output}} {{source}}"
       description = "ASM {{output}}"
       outputs = [
@@ -182,7 +182,7 @@ template("msvc_toolchain") {
       rspfile = "{{output}}.rsp"
 
       link_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $lib /nologo {{arflags}} /OUT:{{output}} @$rspfile"
       description = "LIB {{output}}"
       outputs = [
@@ -203,10 +203,10 @@ template("msvc_toolchain") {
       libname = "${dllname}.lib"  # e.g. foo.dll.lib
       pdbname = "${dllname}.pdb"
       rspfile = "${dllname}.rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /IMPLIB:$libname /DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
 
       default_output_extension = ".dll"
@@ -238,10 +238,10 @@ template("msvc_toolchain") {
       dllname = "{{output_dir}}/{{target_output_name}}{{output_extension}}"  # e.g. foo.dll
       pdbname = "${dllname}.pdb"
       rspfile = "${dllname}.rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
 
       default_output_extension = ".dll"
@@ -264,10 +264,10 @@ template("msvc_toolchain") {
       exename = "{{output_dir}}/{{target_output_name}}{{output_extension}}"
       pdbname = "$exename.pdb"
       rspfile = "$exename.rsp"
-      pool = "$gn_build_dir/toolchain:link_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:link_pool($default_toolchain)"
 
       link_wrapper =
-          rebase_path("$gn_build_dir/toolchain/win/link_wrapper.py", root_build_dir)
+          rebase_path("$gn_root/toolchain/win/link_wrapper.py", root_build_dir)
       command = "$python_path $link_wrapper $env False $link /nologo /OUT:$exename /PDB:$pdbname @$rspfile"
 
       if (linkrepro_root_dir != "") {
@@ -298,20 +298,20 @@ template("msvc_toolchain") {
 
     # These two are really entirely generic, but have to be repeated in
     # each toolchain because GN doesn't allow a template to be used here.
-    # See $gn_build_dir/toolchain/toolchain.gni for details.
+    # See $gn_root/toolchain/toolchain.gni for details.
     tool("stamp") {
       command = stamp_command
       description = stamp_description
-      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:action_pool($default_toolchain)"
     }
     tool("copy") {
       command = copy_command
       description = copy_description
-      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:action_pool($default_toolchain)"
     }
 
     tool("action") {
-      pool = "$gn_build_dir/toolchain:action_pool($default_toolchain)"
+      pool = "$gn_root/toolchain:action_pool($default_toolchain)"
     }
   }
 }

--- a/toolchain/win/manifest.gni
+++ b/toolchain/win/manifest.gni
@@ -23,7 +23,7 @@
 # targets.
 #
 # Generally you will just want the defaults for the Chrome build. In this case
-# the binary should just depend on one of the targets in $gn_build_dir/win/. There
+# the binary should just depend on one of the targets in $gn_root/win/. There
 # are also individual manifest files in that directory you can reference via
 # the *_manifest variables defined below to pick and choose only some defaults.
 # You might combine these with a custom manifest file to get specific behavior.
@@ -73,7 +73,7 @@ if (is_win) {
     action(manifest_action_name) {
       visibility = [ ":$source_set_name" ]
 
-      script = "$gn_build_dir/toolchain/win/manifest_wrapper.py"
+      script = "$gn_root/toolchain/win/manifest_wrapper.py"
 
       assert(defined(invoker.sources),
              "\"sources\" must be defined for a windows_manifest target")
@@ -106,7 +106,7 @@ if (is_win) {
     action(rc_action_name) {
       visibility = [ ":$source_set_name" ]
 
-      script = "$gn_build_dir/toolchain/win/manifest_to_rc.py"
+      script = "$gn_root/toolchain/win/manifest_to_rc.py"
 
       outputs = [
         rcfile,

--- a/toolchain/win/manifest.gni
+++ b/toolchain/win/manifest.gni
@@ -23,7 +23,7 @@
 # targets.
 #
 # Generally you will just want the defaults for the Chrome build. In this case
-# the binary should just depend on one of the targets in //build/win/. There
+# the binary should just depend on one of the targets in $gn_build_dir/win/. There
 # are also individual manifest files in that directory you can reference via
 # the *_manifest variables defined below to pick and choose only some defaults.
 # You might combine these with a custom manifest file to get specific behavior.
@@ -73,7 +73,7 @@ if (is_win) {
     action(manifest_action_name) {
       visibility = [ ":$source_set_name" ]
 
-      script = "//build/toolchain/win/manifest_wrapper.py"
+      script = "$gn_build_dir/toolchain/win/manifest_wrapper.py"
 
       assert(defined(invoker.sources),
              "\"sources\" must be defined for a windows_manifest target")
@@ -106,7 +106,7 @@ if (is_win) {
     action(rc_action_name) {
       visibility = [ ":$source_set_name" ]
 
-      script = "//build/toolchain/win/manifest_to_rc.py"
+      script = "$gn_build_dir/toolchain/win/manifest_to_rc.py"
 
       outputs = [
         rcfile,

--- a/toolchain/win/message_compiler.gni
+++ b/toolchain/win/message_compiler.gni
@@ -38,7 +38,7 @@ template("message_compiler") {
       forward_variables_from(invoker, [ "visibility" ])
     }
 
-    script = "$gn_build_dir/toolchain/win/message_compiler.py"
+    script = "$gn_root/toolchain/win/message_compiler.py"
 
     outputs = [
       "$target_gen_dir/{{source_name_part}}.h",

--- a/toolchain/win/message_compiler.gni
+++ b/toolchain/win/message_compiler.gni
@@ -38,7 +38,7 @@ template("message_compiler") {
       forward_variables_from(invoker, [ "visibility" ])
     }
 
-    script = "//build/toolchain/win/message_compiler.py"
+    script = "$gn_build_dir/toolchain/win/message_compiler.py"
 
     outputs = [
       "$target_gen_dir/{{source_name_part}}.h",

--- a/toolchain/win/midl.gni
+++ b/toolchain/win/midl.gni
@@ -4,7 +4,7 @@
 
 assert(is_win)
 
-import("//build/toolchain/win/settings.gni")
+import("$gn_build_dir/toolchain/win/settings.gni")
 
 # This template defines a rule to invoke the MS IDL compiler. The generated
 # source code will be compiled and linked into targets that depend on this.
@@ -41,7 +41,7 @@ template("midl") {
   action_foreach(action_name) {
     visibility = [ ":$source_set_name" ]
 
-    script = "//build/toolchain/win/midl_wrapper.py"
+    script = "$gn_build_dir/toolchain/win/midl_wrapper.py"
 
     sources = invoker.sources
 
@@ -94,6 +94,6 @@ template("midl") {
       ":$action_name",
     ]
 
-    configs += [ "//build/config/win:midl_warnings" ]
+    configs += [ "$gn_build_dir/config/win:midl_warnings" ]
   }
 }

--- a/toolchain/win/midl.gni
+++ b/toolchain/win/midl.gni
@@ -4,7 +4,7 @@
 
 assert(is_win)
 
-import("$gn_build_dir/toolchain/win/settings.gni")
+import("$gn_root/toolchain/win/settings.gni")
 
 # This template defines a rule to invoke the MS IDL compiler. The generated
 # source code will be compiled and linked into targets that depend on this.
@@ -41,7 +41,7 @@ template("midl") {
   action_foreach(action_name) {
     visibility = [ ":$source_set_name" ]
 
-    script = "$gn_build_dir/toolchain/win/midl_wrapper.py"
+    script = "$gn_root/toolchain/win/midl_wrapper.py"
 
     sources = invoker.sources
 
@@ -94,6 +94,6 @@ template("midl") {
       ":$action_name",
     ]
 
-    configs += [ "$gn_build_dir/config/win:midl_warnings" ]
+    configs += [ "$gn_root/config/win:midl_warnings" ]
   }
 }

--- a/toolchain/win/settings.gni
+++ b/toolchain/win/settings.gni
@@ -1,5 +1,5 @@
 if (is_clang) {
-  import("//build/toolchain/clang.gni")
+  import("$gn_build_dir/toolchain/clang.gni")
 }
 
 declare_args() {

--- a/toolchain/win/settings.gni
+++ b/toolchain/win/settings.gni
@@ -1,5 +1,5 @@
 if (is_clang) {
-  import("$gn_build_dir/toolchain/clang.gni")
+  import("$gn_root/toolchain/clang.gni")
 }
 
 declare_args() {


### PR DESCRIPTION
This commit makes the //build folder movable anywhere in the user's directory structure.
The $gn_root variable was added in `BUILDCONFIG.gn`, and is computed automatically.

This allowed me to move `//build` to `//build/platform` without any issue