### PR TITLE
Add ARM and ARM64 support for POSIX environments

### DIFF
--- a/toolchain/posix/BUILD.gn
+++ b/toolchain/posix/BUILD.gn
@@ -64,3 +64,35 @@ gcc_toolchain("x64") {
     is_clang = false
   }
 }
+
+gcc_toolchain("arm") {
+  cc = gcc_cc
+  cxx = gcc_cxx
+  ld = cxx
+
+  readelf = readelf
+  ar = ar
+  nm = nm
+
+  toolchain_args = {
+    current_cpu = "arm"
+    current_os = target_os
+    is_clang = false
+  }
+}
+
+gcc_toolchain("arm64") {
+  cc = gcc_cc
+  cxx = gcc_cxx
+  ld = cxx
+
+  readelf = readelf
+  ar = ar
+  nm = nm
+
+  toolchain_args = {
+    current_cpu = "arm64"
+    current_os = target_os
+    is_clang = false
+  }
+}


### PR DESCRIPTION
This patch adds ARM/ARM64 toolchain support (POSIX, GCC).

If your ARM toolchain has prefix then you can override gcc_cc and others to use your prefixed toolchain like `gcc_cc=arm-linux-gnueabihf-gcc`
