### PR TITLE
Make /UTF-8 flag on windows a separate config

### DIFF
--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -345,6 +345,16 @@ if (is_win) {
   ]
 }
 
+import("//build_ex/config/project_defaults.gni")
+
+if (defined(default_compiler_configs_add)) {
+  default_compiler_configs += default_compiler_configs_add
+}
+
+if (defined(default_compiler_configs_remove)) {
+  default_compiler_configs -= default_compiler_configs_remove
+}
+
 if (is_android) {
   default_compiler_configs +=
       [ "//build/config/android:default_cygprofile_instrumentation" ]

--- a/toolchain/mac/mac_sdk.gni
+++ b/toolchain/mac/mac_sdk.gni
@@ -53,3 +53,4 @@ _mac_sdk_result = exec_script(script_name, sdk_info_args, "scope")
 xcode_version = _mac_sdk_result.xcode_version
 xcode_build = _mac_sdk_result.xcode_build
 machine_os_build = _mac_sdk_result.machine_os_build
+mac_sdk_build = _mac_sdk_result.sdk_build

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -235,7 +235,7 @@ template("msvc_toolchain") {
       rspfile = "${dllname}.rsp"
       pool = "//build/toolchain:link_pool($default_toolchain)"
 
-      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/IMPLIB:$libname /DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
+      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/IMPLIB:$libname /DLL /OUT:$dllname /PDB:$pdbname /PDBSTRIPPED:${dllname}.stripped.pdb @$rspfile"
 
       default_output_extension = ".dll"
       default_output_dir = "{{root_out_dir}}"
@@ -268,7 +268,7 @@ template("msvc_toolchain") {
       rspfile = "${dllname}.rsp"
       pool = "//build/toolchain:link_pool($default_toolchain)"
 
-      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/DLL /OUT:$dllname /PDB:$pdbname @$rspfile"
+      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/DLL /OUT:$dllname /PDB:$pdbname /PDBSTRIPPED:${dllname}.stripped.pdb @$rspfile"
 
       default_output_extension = ".dll"
       default_output_dir = "{{root_out_dir}}"
@@ -292,7 +292,7 @@ template("msvc_toolchain") {
       rspfile = "$exename.rsp"
       pool = "//build/toolchain:link_pool($default_toolchain)"
 
-      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/OUT:$exename /PDB:$pdbname @$rspfile"
+      command = "$linker_wrapper$link /nologo ${sys_lib_flags}/OUT:$exename /PDB:$pdbname /PDBSTRIPPED:${exename}.stripped.pdb @$rspfile"
 
       if (linkrepro_root_dir != "") {
         # Create the directory that will receive the link repro for this target


### PR DESCRIPTION
Hi, 

thank you for your work on this. We've been using heavily customized build from Chromium, but over time got stale so I was more than happy to replace it with your fork.

One of our dependency unfortunately uses Windows-1252 for header files encoding and forcing /UTF-8 makes MSVC complain about it.

It would be great if this was a separate config so that we can remove it where necessary.