### PR TITLE
Support SDK of MacOSX 11

### DIFF
--- a/config/mac/BUILD.gn
+++ b/config/mac/BUILD.gn
@@ -130,7 +130,7 @@ config("strip_all") {
 # This is included by reference in the //build/config/default_libs config.
 config("default_libs") {
   if (mac_use_sdk) {
-    libs = [
+    frameworks = [
       "AppKit.framework",
       "ApplicationServices.framework",
       "Carbon.framework",

--- a/toolchain/mac/BUILD.gn
+++ b/toolchain/mac/BUILD.gn
@@ -321,7 +321,7 @@ template("mac_toolchain") {
       # do for command-line arguments. Thus any source names with spaces, or
       # label names with spaces (which GN bases the output paths on) will be
       # corrupted by this process. Don't use spaces for source files or labels.
-      command = "$env_wrapper $linker_driver $ld $dsym_switch {{ldflags}} -o \"$outfile\" -Wl,-filelist,\"$rspfile\" {{solibs}} {{libs}}"
+      command = "$env_wrapper $linker_driver $ld $dsym_switch {{ldflags}} -o \"$outfile\" -Wl,-filelist,\"$rspfile\" {{solibs}} {{libs}} {{frameworks}}"
       description = "LINK $outfile"
       rspfile_content = "{{inputs_newline}}"
       outputs = [

--- a/toolchain/mac/find_sdk.py
+++ b/toolchain/mac/find_sdk.py
@@ -54,7 +54,7 @@ def main():
     raise Exception('Error %d running xcode-select' % job.returncode)
   sdk_dir = os.path.join(
       out.rstrip(), 'Platforms/MacOSX.platform/Developer/SDKs')
-  sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+  sdks = [re.findall('^MacOSX(\d+\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
   sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
   sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
           if (parse_version(s) >= parse_version(min_sdk_version))]


### PR DESCRIPTION
As new version SDK like this below:
```
$ xcode-select -print-path
/Applications/Xcode.app/Contents/Developer

$ ls /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
DriverKit20.2.sdk MacOSX.sdk        MacOSX11.1.sdk
```

And #29, change `libs` to `frameworks`


Is this change right?