### PR TITLE
macOS fixes

### DIFF
--- a/toolchain/mac/filter_libtool.py
+++ b/toolchain/mac/filter_libtool.py
@@ -25,7 +25,7 @@ def Main(cmd_list):
   env['ZERO_AR_DATE'] = '1'
   libtoolout = subprocess.Popen(cmd_list, stderr=subprocess.PIPE, env=env)
   _, err = libtoolout.communicate()
-  for line in err.splitlines():
+  for line in err.decode("utf-8").splitlines():
     if not libtool_re.match(line) and not libtool_re5.match(line):
       print(line, file=sys.stderr)
   # Unconditionally touch the output .a file on the command line if present

--- a/toolchain/mac/find_sdk.py
+++ b/toolchain/mac/find_sdk.py
@@ -55,6 +55,7 @@ def main():
   sdk_dir = os.path.join(
       out.rstrip(), 'Platforms/MacOSX.platform/Developer/SDKs')
   sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+  sdks += [re.findall('^MacOSX(11\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
   sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
   sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
           if (parse_version(s) >= parse_version(min_sdk_version))]


### PR DESCRIPTION
This PR enables macOS SDK 11.x support and forces filter_libtool.py to use UTF-8 in some cases (was required on macOS).