### PR TITLE
Small tweaks for clang cross compilation cases

### DIFF
--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/compiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 import("//build/toolchain/toolchain.gni")
 import("//build/toolchain/clang.gni")
+import("//build/toolchain/sysroot.gni")
 
 if (current_cpu == "arm" || current_cpu == "arm64") {
   import("//build/config/arm.gni")
@@ -255,6 +256,12 @@ config("compiler") {
 
     # Let clang find the linker in the NDK.
     ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root" ]
+  } else if (use_sysroot && is_clang) {
+    _rebased_toolchain_root =
+        rebase_path(sysroot, root_build_dir)
+
+    cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+    ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
   }
 
   if (is_posix && use_lld) {

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -262,6 +262,12 @@ config("compiler") {
 
     cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
     ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+  } else if (gcc_toolchain != "" && is_clang) {
+    _rebased_toolchain_root =
+        rebase_path(gcc_toolchain, root_build_dir)
+
+    cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+    ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
   }
 
   if (is_posix && use_lld) {

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -1242,7 +1242,14 @@ config("symbols") {
         "-g2",
       ]
     } else {
-      cflags = [ "-g2" ]
+      if (dwarf_version > 0) {
+        cflags = [
+          "-gdwarf-$dwarf_version",
+          "-g2",
+        ]
+      } else {
+        cflags = [ "-g2" ]
+      }
     }
     if (use_debug_fission) {
       cflags += [ "-gsplit-dwarf" ]

--- a/config/compiler.gni
+++ b/config/compiler.gni
@@ -17,6 +17,9 @@ declare_args() {
   # Enable some optimizations that don't interfere with debugging.
   optimize_debug = false
 
+  # DWARF version
+  dwarf_version = 0
+
   # use_debug_fission: whether to use split DWARF debug info
   # files. This can reduce link time significantly, but is incompatible
   # with some utilities such as icecc and ccache. Requires gold and

--- a/toolchain/clang.gni
+++ b/toolchain/clang.gni
@@ -18,6 +18,9 @@ declare_args() {
   # http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
   # TODO(tim): Supported on Windows?
   use_thin_lto = false
+
+  # Value of --gcc-toolchain
+  gcc_toolchain = ""
 }
 
 if (is_win && is_clang) {

--- a/toolchain/posix/BUILD.gn
+++ b/toolchain/posix/BUILD.gn
@@ -65,6 +65,22 @@ gcc_toolchain("x64") {
   }
 }
 
+gcc_toolchain("clang_arm") {
+  cc = clang_cc
+  cxx = clang_cxx
+  ld = cxx
+
+  readelf = readelf
+  ar = ar
+  nm = nm
+
+  toolchain_args = {
+    current_cpu = "arm"
+    current_os = target_os
+    is_clang = true
+  }
+}
+
 gcc_toolchain("arm") {
   cc = gcc_cc
   cxx = gcc_cxx
@@ -78,6 +94,22 @@ gcc_toolchain("arm") {
     current_cpu = "arm"
     current_os = target_os
     is_clang = false
+  }
+}
+
+gcc_toolchain("clang_arm64") {
+  cc = clang_cc
+  cxx = clang_cxx
+  ld = cxx
+
+  readelf = readelf
+  ar = ar
+  nm = nm
+
+  toolchain_args = {
+    current_cpu = "arm64"
+    current_os = target_os
+    is_clang = true
   }
 }
 


### PR DESCRIPTION
- Add --gcc-toolchain to clang flags if sysroot is used (sometimes clang is unable to auto-detect gcc toolchain)
- Add gcc_toolchain option for clang - for the case when you are cross-compiling on Ubuntu for Ubuntu via Ubuntu's multiach support
- Add dwarf_version argument for clang - dwarf 4+ is not always compatible with binutils used for target OS