### PR TITLE
Small tweaks for clang cross compilation cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ which is used for all POSIX systems that don't have special toolchains.
 
 * `android_ndk_root` (default: "$external/android_tools/ndk"):
   Path of the Android NDK.
-* `android_ndk_version` (default: "r12b"): NDK Version string.
-* `android_ndk_major_version` (default: 12): NDK Major version.
+* `android_ndk_version` (default: "r25b"): NDK Version string.
+* `android_ndk_major_version` (default: 25): NDK Major version.
 * `android_sdk_root` (default: "$external/android_tools/sdk"):
   Path of the Android SDK.
 * `android_sdk_version` (default: "24"): Android SDK version.

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -258,7 +258,7 @@ config("compiler") {
 
     # Let clang find the linker in the NDK.
     ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root", "-resource-dir=$_rebased_android_toolchain_resource_dir" ]
-  } else if (gcc_toolchain == "" && use_sysroot && is_clang) {
+  } else if (gcc_toolchain == "" && use_sysroot && is_clang && !is_mac) {
     _rebased_toolchain_root =
         rebase_path(sysroot, root_build_dir)
 

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -274,7 +274,7 @@ config("compiler") {
 
   if (is_posix && use_lld) {
     ldflags += [ "-fuse-ld=lld" ]
-    if (current_cpu == "arm64") {
+    if (current_cpu == "arm64" && !is_mac) {
       # Reduce the page size from 65536 in order to reduce binary size slightly
       # by shrinking the alignment gap between segments. This also causes all
       # segments to be mapped adjacently, which breakpad relies on.

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -253,9 +253,11 @@ config("compiler") {
   if (is_android && is_clang) {
     _rebased_android_toolchain_root =
         rebase_path(android_toolchain_root, root_build_dir)
+    _rebased_android_toolchain_resource_dir =
+        rebase_path(android_toolchain_resource_dir, root_build_dir)
 
     # Let clang find the linker in the NDK.
-    ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root" ]
+    ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root", "-resource-dir=$_rebased_android_toolchain_resource_dir" ]
   } else if (gcc_toolchain == "" && use_sysroot && is_clang) {
     _rebased_toolchain_root =
         rebase_path(sysroot, root_build_dir)

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -436,14 +436,24 @@ config("compiler_cpu_abi") {
     # CPU architecture. We may or may not be doing a cross compile now, so for
     # simplicity we always explicitly set the architecture.
     if (current_cpu == "x64") {
-      cflags += [
-        "-m64",
-        "-march=x86-64",
-      ]
-      ldflags += [ "-m64" ]
+      if (is_clang && is_linux && !is_android) {
+        cflags += [ "--target=x86_64-linux-gnu" ]
+        ldflags += [ "--target=x86_64-linux-gnu" ]
+      } else {
+        cflags += [
+          "-m64",
+          "-march=x86-64",
+        ]
+        ldflags += [ "-m64" ]
+      }
     } else if (current_cpu == "x86") {
-      cflags += [ "-m32" ]
-      ldflags += [ "-m32" ]
+      if (is_clang && is_linux && !is_android) {
+        cflags += [ "--target=i386-linux-gnu" ]
+        ldflags += [ "--target=i386-linux-gnu" ]
+      } else {
+        cflags += [ "-m32" ]
+        ldflags += [ "-m32" ]
+      }
     } else if (current_cpu == "arm") {
       if (is_clang && !is_android) {
         cflags += [ "--target=arm-linux-gnueabihf" ]

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/compiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 import("//build/toolchain/toolchain.gni")
 import("//build/toolchain/clang.gni")
+import("//build/toolchain/sysroot.gni")
 
 if (current_cpu == "arm" || current_cpu == "arm64") {
   import("//build/config/arm.gni")
@@ -255,6 +256,12 @@ config("compiler") {
 
     # Let clang find the linker in the NDK.
     ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root" ]
+  } else if (use_sysroot && is_clang) {
+    _rebased_toolchain_root =
+        rebase_path(sysroot, root_build_dir)
+
+    cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+    ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
   }
 
   if (is_posix && use_lld) {

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -256,7 +256,7 @@ config("compiler") {
 
     # Let clang find the linker in the NDK.
     ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root" ]
-  } else if (use_sysroot && is_clang) {
+  } else if (gcc_toolchain == "" && use_sysroot && is_clang) {
     _rebased_toolchain_root =
         rebase_path(sysroot, root_build_dir)
 

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -262,6 +262,12 @@ config("compiler") {
 
     cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
     ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+  } else if (gcc_toolchain != "" && is_clang) {
+    _rebased_toolchain_root =
+        rebase_path(gcc_toolchain, root_build_dir)
+
+    cflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
+    ldflags += [ "--gcc-toolchain=$_rebased_toolchain_root" ]
   }
 
   if (is_posix && use_lld) {

--- a/config/BUILD.gn
+++ b/config/BUILD.gn
@@ -1242,7 +1242,14 @@ config("symbols") {
         "-g2",
       ]
     } else {
-      cflags = [ "-g2" ]
+      if (dwarf_version > 0) {
+        cflags = [
+          "-gdwarf-$dwarf_version",
+          "-g2",
+        ]
+      } else {
+        cflags = [ "-g2" ]
+      }
     }
     if (use_debug_fission) {
       cflags += [ "-gsplit-dwarf" ]

--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -211,8 +211,7 @@ if (target_os == "android") {
 } else if (target_os == "ios") {
   _default_toolchain = "//build/toolchain/mac:ios_clang_$target_cpu"
 } else if (target_os == "mac") {
-  assert(host_os == "mac", "Mac cross-compiles are unsupported.")
-  _default_toolchain = host_toolchain
+  _default_toolchain = "//build/toolchain/mac:clang_$target_cpu"
 } else if (target_os == "win") {
   if (is_clang) {
     _default_toolchain = "//build/toolchain/win:clang_$target_cpu"

--- a/config/BUILDCONFIG.gn
+++ b/config/BUILDCONFIG.gn
@@ -214,8 +214,6 @@ if (target_os == "android") {
   assert(host_os == "mac", "Mac cross-compiles are unsupported.")
   _default_toolchain = host_toolchain
 } else if (target_os == "win") {
-  # On Windows we use the same toolchain for host and target by default.
-  assert(target_os == host_os, "Win cross-compiles only work on win hosts.")
   if (is_clang) {
     _default_toolchain = "//build/toolchain/win:clang_$target_cpu"
   } else {

--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/toolchain/sysroot.gni")
 import("//build/toolchain/android/settings.gni")
 import("//build/config/sanitizers/sanitizers.gni")
 
@@ -23,7 +24,7 @@ config("compiler") {
     "HAVE_SYS_UIO_H",
 
     # Forces full rebuilds on NDK rolls.
-    "ANDROID_NDK_VERSION=${android_ndk_version}",
+    #"ANDROID_NDK_VERSION=${android_ndk_version}",
   ]
 
   _rebased_android_toolchain_root =
@@ -87,19 +88,22 @@ config("runtime_library") {
   # caution.
   cflags_cc = []
 
-  assert(android_ndk_major_version >= 25, "Android NDK older than r25b are not supported")
+  #assert(android_ndk_major_version >= 25, "Android NDK older than r25b are not supported")
 
   cflags_cc += [
     # "-isystem" + rebase_path("$android_libcpp_root/include", root_build_dir),
     # "-isystem" + rebase_path("$android_ndk_root/sources/cxx-stl/llvm-libc++abi/include", root_build_dir),
-    "-isystem" +
-        rebase_path("$android_ndk_root/sources/android/support/include",
-                    root_build_dir),
+    # "-isystem" + rebase_path("$android_ndk_root/sources/android/support/include", root_build_dir),
   ]
 
   defines = [ "__GNU_SOURCE=1" ]  # Necessary for clone().
   ldflags = [ "-nostartfiles" ]
-  lib_dirs = [ android_libcpp_lib_dir ]
+
+  lib_dirs = [
+    # android_libcpp_lib_dir,
+    sysroot + "/usr/lib/aarch64-linux-android",
+    sysroot + "/usr/lib/aarch64-linux-android/" + android_sdk_version,
+  ]
 
   # The libc++ runtime library (must come first).
   # ASan needs to dynamically link to libc++ even in static builds so

--- a/config/android/BUILD.gn
+++ b/config/android/BUILD.gn
@@ -26,20 +26,16 @@ config("compiler") {
     "ANDROID_NDK_VERSION=${android_ndk_version}",
   ]
 
-  if (is_clang) {
-    rebased_android_toolchain_root =
-        rebase_path(android_toolchain_root, root_build_dir)
-    assert(rebased_android_toolchain_root != "")  # Mark as used.
-    if (current_cpu == "mipsel" || current_cpu == "mips64el") {
-      cflags += [
-        # TODO(gordanac) Enable integrated-as.
-        "-fno-integrated-as",
-        "-B${rebased_android_toolchain_root}/bin",  # Else /usr/bin/as gets picked up.
-      ]
-    }
-  } else {
-    # Clang doesn't support these flags.
-    cflags += [ "-finline-limit=64" ]
+  _rebased_android_toolchain_root =
+      rebase_path(android_toolchain_root, root_build_dir)
+
+  assert(_rebased_android_toolchain_root != "")  # Mark as used.
+  if (current_cpu == "mipsel" || current_cpu == "mips64el") {
+    cflags += [
+      # TODO(gordanac) Enable integrated-as.
+      "-fno-integrated-as",
+      "-B${_rebased_android_toolchain_root}/bin",  # Else /usr/bin/as gets picked up.
+    ]
   }
 
   ldflags = [
@@ -52,34 +48,26 @@ config("compiler") {
     "-Wl,--exclude-libs=libc++_static.a",
   ]
 
-  if (is_clang) {
-    _rebased_android_toolchain_root =
-        rebase_path(android_toolchain_root, root_build_dir)
-
-    # Let clang find the linker in the NDK.
-    ldflags += [ "--gcc-toolchain=$_rebased_android_toolchain_root" ]
-
-    if (current_cpu == "arm") {
-      abi_target = "arm-linux-androideabi"
-    } else if (current_cpu == "x86") {
-      abi_target = "i686-linux-androideabi"
-    } else if (current_cpu == "arm64") {
-      abi_target = "aarch64-linux-android"
-    } else if (current_cpu == "x64") {
-      # Place holder for x64 support, not tested.
-      # TODO: Enable clang support for Android x64. http://crbug.com/539781
-      abi_target = "x86_64-linux-androideabi"
-    } else if (current_cpu == "mipsel") {
-      abi_target = "mipsel-linux-android"
-    } else if (current_cpu == "mips64el") {
-      # Place holder for mips64 support, not tested.
-      abi_target = "mips64el-linux-androideabi"
-    } else {
-      assert(false, "Architecture not supported")
-    }
-    cflags += [ "--target=$abi_target" ]
-    ldflags += [ "--target=$abi_target" ]
+  if (current_cpu == "arm") {
+    abi_target = "arm-linux-androideabi"
+  } else if (current_cpu == "x86") {
+    abi_target = "i686-linux-androideabi"
+  } else if (current_cpu == "arm64") {
+    abi_target = "aarch64-linux-android"
+  } else if (current_cpu == "x64") {
+    # Place holder for x64 support, not tested.
+    # TODO: Enable clang support for Android x64. http://crbug.com/539781
+    abi_target = "x86_64-linux-androideabi"
+  } else if (current_cpu == "mipsel") {
+    abi_target = "mipsel-linux-android"
+  } else if (current_cpu == "mips64el") {
+    # Place holder for mips64 support, not tested.
+    abi_target = "mips64el-linux-androideabi"
+  } else {
+    assert(false, "Architecture not supported")
   }
+  cflags += [ "--target=$abi_target" ]
+  ldflags += [ "--target=$abi_target" ]
 
   # Assign any flags set for the C compiler to asmflags so that they are sent
   # to the assembler.
@@ -98,36 +86,19 @@ config("runtime_library") {
   # strange errors. The include ordering here is important; change with
   # caution.
   cflags_cc = []
-  if (android_ndk_major_version >= 13) {
-    libcxx_include_path =
-        rebase_path("$android_libcpp_root/include", root_build_dir)
-    libcxxabi_include_path =
-        rebase_path("$android_ndk_root/sources/cxx-stl/llvm-libc++abi/include",
-                    root_build_dir)
 
-    if (!is_clang) {
-      # Per the release notes, GCC is not supported in the NDK starting with
-      # r13. It's still present, though, and has conflicting declarations of
-      # float abs(float).
-      cflags_cc += [ "-Wno-attributes" ]
-    }
-  } else {
-    libcxx_include_path =
-        rebase_path("$android_libcpp_root/libcxx/include", root_build_dir)
-    libcxxabi_include_path = rebase_path(
-            "$android_ndk_root/sources/cxx-stl/llvm-libc++abi/libcxxabi/include",
-            root_build_dir)
-  }
+  assert(android_ndk_major_version >= 25, "Android NDK older than r25b are not supported")
+
   cflags_cc += [
-    "-isystem" + libcxx_include_path,
-    "-isystem" + libcxxabi_include_path,
+    # "-isystem" + rebase_path("$android_libcpp_root/include", root_build_dir),
+    # "-isystem" + rebase_path("$android_ndk_root/sources/cxx-stl/llvm-libc++abi/include", root_build_dir),
     "-isystem" +
         rebase_path("$android_ndk_root/sources/android/support/include",
                     root_build_dir),
   ]
 
   defines = [ "__GNU_SOURCE=1" ]  # Necessary for clone().
-  ldflags = [ "-nostdlib" ]
+  ldflags = [ "-nostartfiles" ]
   lib_dirs = [ android_libcpp_lib_dir ]
 
   # The libc++ runtime library (must come first).
@@ -138,49 +109,35 @@ config("runtime_library") {
   } else {
     libs = [ "c++_static" ]
   }
-  libs += [
-    "c++abi",
-    "android_support",
-  ]
+  libs += [ "c++abi" ]
 
-  # arm builds of libc++ starting in NDK r12 depend on unwind.
-  if (current_cpu == "arm") {
-    libs += [ "unwind" ]
+  if (current_cpu == "arm" || current_cpu == "x86") {
+    libs += [ "android_support" ]
   }
 
   # Manually link the libgcc.a that the cross compiler uses. This is
   # absolute because the linker will look inside the sysroot if it's not.
-  libs += [
-    rebase_path(android_libgcc_file),
-    "c",
+  libs += [ "unwind", "c" ]
+
+  # Work around incompatibilities between bionic and clang headers.
+  defines += [
+    "__compiler_offsetof=__builtin_offsetof",
+    "nan=__builtin_nan",
   ]
 
-  # Clang with libc++ does not require an explicit atomic library reference.
-  if (!is_clang) {
-    libs += [ "atomic" ]
-  }
-
-  if (is_clang) {
-    # Work around incompatibilities between bionic and clang headers.
-    defines += [
-      "__compiler_offsetof=__builtin_offsetof",
-      "nan=__builtin_nan",
-    ]
-
-    if (current_cpu == "x64" || current_cpu == "arm64" ||
-        current_cpu == "mips64el") {
-      # 64-bit targets build with NDK 21, 32-bit targets with NDK 16
-      # (see ./config.gni).  When using clang, NDK 21 defines snprintf to
-      # something for a kind of for of _FORTIFY_SOURCE support, see
-      # third_party/android_tools/ndk/platforms/android-21/arch-x86_64/usr/include/stdio.h
-      # Making snprintf a macro breaks base/strings/string_utils.h which
-      # defines base::snprintf().  So define snprintf to itself to force the
-      # NDK to not redefine it.  This disables _chk for snprintf, but since
-      # 32-bit versions use NDK 16 which doesn't have any fortify support, that
-      # seems ok.  b/32067310 tracks better fortify support with clang.
-      # TODO(thakis): Remove this once b/32067310 is fixed.
-      defines += [ "snprintf=snprintf" ]
-    }
+  if (current_cpu == "x64" || current_cpu == "arm64" ||
+      current_cpu == "mips64el") {
+    # 64-bit targets build with NDK 21, 32-bit targets with NDK 16
+    # (see ./config.gni).  When using clang, NDK 21 defines snprintf to
+    # something for a kind of for of _FORTIFY_SOURCE support, see
+    # third_party/android_tools/ndk/platforms/android-21/arch-x86_64/usr/include/stdio.h
+    # Making snprintf a macro breaks base/strings/string_utils.h which
+    # defines base::snprintf().  So define snprintf to itself to force the
+    # NDK to not redefine it.  This disables _chk for snprintf, but since
+    # 32-bit versions use NDK 16 which doesn't have any fortify support, that
+    # seems ok.  b/32067310 tracks better fortify support with clang.
+    # TODO(thakis): Remove this once b/32067310 is fixed.
+    defines += [ "snprintf=snprintf" ]
   }
 
   # TODO(jdduke) Re-enable on mips after resolving linking
@@ -216,17 +173,6 @@ config("default_cygprofile_instrumentation") {
 config("cygprofile_instrumentation") {
   defines = [ "CYGPROFILE_INSTRUMENTATION=1" ]
   cflags = [ "-finstrument-functions" ]
-
-  if (!is_clang) {
-    cflags += [
-      # Allow mmx intrinsics to inline, so that the compiler can expand the intrinsics.
-      "-finstrument-functions-exclude-file-list=mmintrin.h",
-
-      # Avoid errors with current NDK:
-      # "third_party/android_tools/ndk/toolchains/arm-linux-androideabi-4.6/prebuilt/linux-x86_64/bin/../lib/gcc/arm-linux-androideabi/4.6/include/arm_neon.h:3426:3: error: argument must be a constant"
-      "-finstrument-functions-exclude-file-list=arm_neon.h",
-    ]
-  }
 }
 
 config("no_cygprofile_instrumentation") {

--- a/config/compiler.gni
+++ b/config/compiler.gni
@@ -17,6 +17,9 @@ declare_args() {
   # Enable some optimizations that don't interfere with debugging.
   optimize_debug = false
 
+  # DWARF version
+  dwarf_version = 0
+
   # use_debug_fission: whether to use split DWARF debug info
   # files. This can reduce link time significantly, but is incompatible
   # with some utilities such as icecc and ccache. Requires gold and

--- a/config/mac/BUILD.gn
+++ b/config/mac/BUILD.gn
@@ -68,6 +68,9 @@ config("runtime_library") {
     common_flags = [
       "-isysroot",
       rebase_path(sysroot, root_build_dir),
+      "-nostdinc++",
+      "-I",
+      rebase_path(sysroot, root_build_dir) + "/usr/include/c++/v1",
       "-mmacosx-version-min=$mac_deployment_target",
     ]
   } else {

--- a/config/mac/BUILD.gn
+++ b/config/mac/BUILD.gn
@@ -64,7 +64,7 @@ config("compiler") {
 # that is Mac-only. Please see that target for advice on what should go in
 # :runtime_library vs. :compiler.
 config("runtime_library") {
-  if (mac_use_sdk) {
+  if (sysroot != "") {
     common_flags = [
       "-isysroot",
       rebase_path(sysroot, root_build_dir),

--- a/config/win/BUILD.gn
+++ b/config/win/BUILD.gn
@@ -322,8 +322,8 @@ config("default_crt") {
     # CRT in Visual Studio releases related to Windows store applications.
     configs = [ ":dynamic_crt" ]
   } else {
-    # Desktop Windows: static CRT.
-    configs = [ ":static_crt" ]
+    # Desktop Windows: dynamic CRT.
+    configs = [ ":dynamic_crt" ]
   }
 }
 

--- a/pkg-config/pkg-config.gni
+++ b/pkg-config/pkg-config.gni
@@ -1,0 +1,132 @@
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//build/toolchain/sysroot.gni")
+
+# Defines a config specifying the result of running pkg-config for the given
+# packages. Put the package names you want to query in the "packages" variable
+# inside the template invocation.
+#
+# You can also add defines via the "defines" variable. This can be useful to
+# add this to the config to pass defines that the library expects to get by
+# users of its headers.
+#
+# Example:
+#   pkg_config("mything") {
+#     packages = [ "mything1", "mything2" ]
+#     defines = [ "ENABLE_AWESOME" ]
+#   }
+#
+# You can also use "extra args" to filter out results (see pkg-config.py):
+#   extra_args = [ "-v, "foo" ]
+# To ignore libs and ldflags (only cflags/defines will be set, which is useful
+# when doing manual dynamic linking), set:
+#   ignore_libs = true
+
+declare_args() {
+  # A pkg-config wrapper to call instead of trying to find and call the right
+  # pkg-config directly. Wrappers like this are common in cross-compilation
+  # environments.
+  # Leaving it blank defaults to searching PATH for 'pkg-config' and relying on
+  # the sysroot mechanism to find the right .pc files.
+  pkg_config = ""
+
+  # A optional pkg-config wrapper to use for tools built on the host.
+  host_pkg_config = ""
+
+  # CrOS systemroots place pkgconfig files at <systemroot>/usr/share/pkgconfig
+  # and one of <systemroot>/usr/lib/pkgconfig or <systemroot>/usr/lib64/pkgconfig
+  # depending on whether the systemroot is for a 32 or 64 bit architecture.
+  #
+  # When build under GYP, CrOS board builds specify the 'system_libdir' variable
+  # as part of the GYP_DEFINES provided by the CrOS emerge build or simple
+  # chrome build scheme. This variable permits controlling this for GN builds
+  # in similar fashion by setting the `system_libdir` variable in the build's
+  # args.gn file to 'lib' or 'lib64' as appropriate for the target architecture.
+  system_libdir = "lib"
+}
+
+pkg_config_script = "//build/pkg-config/pkg-config.py"
+
+# Define the args we pass to the pkg-config script for other build files that
+# need to invoke it manually.
+pkg_config_args = []
+
+if (sysroot != "") {
+  # Pass the sysroot if we're using one (it requires the CPU arch also).
+  pkg_config_args += [
+    "-s",
+    rebase_path(sysroot),
+    "-a",
+    current_cpu,
+  ]
+}
+
+if (pkg_config != "") {
+  pkg_config_args += [
+    "-p",
+    pkg_config,
+  ]
+}
+
+# Only use the custom libdir when building with the target sysroot.
+if (target_sysroot != "" && sysroot == target_sysroot) {
+  pkg_config_args += [
+    "--system_libdir",
+    system_libdir,
+  ]
+}
+
+if (host_pkg_config != "") {
+  host_pkg_config_args = [
+    "-p",
+    host_pkg_config,
+  ]
+} else {
+  host_pkg_config_args = pkg_config_args
+}
+
+template("pkg_config") {
+  assert(defined(invoker.packages),
+         "Variable |packages| must be defined to be a list in pkg_config.")
+  config(target_name) {
+    if (host_toolchain == current_toolchain) {
+      args = host_pkg_config_args + invoker.packages
+    } else {
+      args = pkg_config_args + invoker.packages
+    }
+    if (defined(invoker.extra_args)) {
+      args += invoker.extra_args
+    }
+
+    pkgresult = exec_script(pkg_config_script, args, "value")
+    cflags = pkgresult[1]
+
+    foreach(include, pkgresult[0]) {
+      if (use_sysroot) {
+        # We want the system include paths to use -isystem instead of -I to
+        # suppress warnings in those headers.
+        include_relativized = rebase_path(include, root_build_dir)
+        cflags += [ "-I$include_relativized" ]
+      } else {
+        cflags += [ "-I$include" ]
+      }
+    }
+
+    if (!defined(invoker.ignore_libs) || !invoker.ignore_libs) {
+      libs = pkgresult[2]
+      lib_dirs = pkgresult[3]
+      ldflags = []
+      foreach(lib_dir, pkgresult[3]) {
+        ldflags += [ "-Wl,-rpath-link=$lib_dir" ]
+      }
+    }
+
+    forward_variables_from(invoker,
+                           [
+                             "defines",
+                             "visibility",
+                           ])
+  }
+}

--- a/pkg-config/pkg-config.py
+++ b/pkg-config/pkg-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2013 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/pkg-config/pkg-config.py
+++ b/pkg-config/pkg-config.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python
+# Copyright (c) 2013 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+from __future__ import print_function
+
+import json
+import os
+import subprocess
+import sys
+import re
+from optparse import OptionParser
+
+# This script runs pkg-config, optionally filtering out some results, and
+# returns the result.
+#
+# The result will be [ <includes>, <cflags>, <libs>, <lib_dirs>, <ldflags> ]
+# where each member is itself a list of strings.
+#
+# You can filter out matches using "-v <regexp>" where all results from
+# pkgconfig matching the given regular expression will be ignored. You can
+# specify more than one regular expression my specifying "-v" more than once.
+#
+# You can specify a sysroot using "-s <sysroot>" where sysroot is the absolute
+# system path to the sysroot used for compiling. This script will attempt to
+# generate correct paths for the sysroot.
+#
+# When using a sysroot, you must also specify the architecture via
+# "-a <arch>" where arch is either "x86" or "x64".
+#
+# CrOS systemroots place pkgconfig files at <systemroot>/usr/share/pkgconfig
+# and one of <systemroot>/usr/lib/pkgconfig or <systemroot>/usr/lib64/pkgconfig
+# depending on whether the systemroot is for a 32 or 64 bit architecture. They
+# specify the 'lib' or 'lib64' of the pkgconfig path by defining the
+# 'system_libdir' variable in the args.gn file. pkg_config.gni communicates this
+# variable to this script with the "--system_libdir <system_libdir>" flag. If no
+# flag is provided, then pkgconfig files are assumed to come from
+# <systemroot>/usr/lib/pkgconfig.
+#
+# Additionally, you can specify the option --atleast-version. This will skip
+# the normal outputting of a dictionary and instead print true or false,
+# depending on the return value of pkg-config for the given package.
+
+
+def SetConfigPath(options):
+  """Set the PKG_CONFIG_LIBDIR environment variable.
+
+  This takes into account any sysroot and architecture specification from the
+  options on the given command line.
+  """
+
+  sysroot = options.sysroot
+  assert sysroot
+
+  # Compute the library path name based on the architecture.
+  arch = options.arch
+  if sysroot and not arch:
+    print("You must specify an architecture via -a if using a sysroot.")
+    sys.exit(1)
+
+  libdir = sysroot + '/usr/' + options.system_libdir + '/pkgconfig'
+  libdir += ':' + sysroot + '/usr/share/pkgconfig'
+  os.environ['PKG_CONFIG_LIBDIR'] = libdir
+  return libdir
+
+
+def GetPkgConfigPrefixToStrip(options, args):
+  """Returns the prefix from pkg-config where packages are installed.
+
+  This returned prefix is the one that should be stripped from the beginning of
+  directory names to take into account sysroots.
+  """
+  # Some sysroots, like the Chromium OS ones, may generate paths that are not
+  # relative to the sysroot. For example,
+  # /path/to/chroot/build/x86-generic/usr/lib/pkgconfig/pkg.pc may have all
+  # paths relative to /path/to/chroot (i.e. prefix=/build/x86-generic/usr)
+  # instead of relative to /path/to/chroot/build/x86-generic (i.e prefix=/usr).
+  # To support this correctly, it's necessary to extract the prefix to strip
+  # from pkg-config's |prefix| variable.
+  prefix = subprocess.check_output([options.pkg_config,
+      "--variable=prefix"] + args, env=os.environ).decode('utf-8')
+  if prefix[-4] == '/usr':
+    return prefix[4:]
+  return prefix
+
+
+def MatchesAnyRegexp(flag, list_of_regexps):
+  """Returns true if the first argument matches any regular expression in the
+  given list."""
+  for regexp in list_of_regexps:
+    if regexp.search(flag) != None:
+      return True
+  return False
+
+
+def RewritePath(path, strip_prefix, sysroot):
+  """Rewrites a path by stripping the prefix and prepending the sysroot."""
+  if os.path.isabs(path) and not path.startswith(sysroot):
+    if path.startswith(strip_prefix):
+      path = path[len(strip_prefix):]
+    path = path.lstrip('/')
+    return os.path.join(sysroot, path)
+  else:
+    return path
+
+
+def main():
+  # If this is run on non-Linux platforms, just return nothing and indicate
+  # success. This allows us to "kind of emulate" a Linux build from other
+  # platforms.
+  if "linux" not in sys.platform and "darwin" not in sys.platform:
+    print("[[],[],[],[],[]]")
+    return 0
+
+  parser = OptionParser()
+  parser.add_option('-d', '--debug', action='store_true')
+  parser.add_option('-p', action='store', dest='pkg_config', type='string',
+                    default='pkg-config')
+  parser.add_option('-v', action='append', dest='strip_out', type='string')
+  parser.add_option('-s', action='store', dest='sysroot', type='string')
+  parser.add_option('-a', action='store', dest='arch', type='string')
+  parser.add_option('--system_libdir', action='store', dest='system_libdir',
+                    type='string', default='lib')
+  parser.add_option('--atleast-version', action='store',
+                    dest='atleast_version', type='string')
+  parser.add_option('--libdir', action='store_true', dest='libdir')
+  parser.add_option('--dridriverdir', action='store_true', dest='dridriverdir')
+  parser.add_option('--version-as-components', action='store_true',
+                    dest='version_as_components')
+  (options, args) = parser.parse_args()
+
+  # Make a list of regular expressions to strip out.
+  strip_out = []
+  if options.strip_out != None:
+    for regexp in options.strip_out:
+      strip_out.append(re.compile(regexp))
+
+  if options.sysroot:
+    libdir = SetConfigPath(options)
+    if options.debug:
+      sys.stderr.write('PKG_CONFIG_LIBDIR=%s\n' % libdir)
+    prefix = GetPkgConfigPrefixToStrip(options, args)
+  else:
+    prefix = ''
+
+  if options.atleast_version:
+    # When asking for the return value, just run pkg-config and print the return
+    # value, no need to do other work.
+    if not subprocess.call([options.pkg_config,
+                            "--atleast-version=" + options.atleast_version] +
+                            args):
+      print("true")
+    else:
+      print("false")
+    return 0
+
+  if options.version_as_components:
+    cmd = [options.pkg_config, "--modversion"] + args
+    try:
+      version_string = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      sys.stderr.write('Error from pkg-config.\n')
+      return 1
+    print(json.dumps(list(map(int, version_string.strip().split(".")))))
+    return 0
+
+
+  if options.libdir:
+    cmd = [options.pkg_config, "--variable=libdir"] + args
+    if options.debug:
+      sys.stderr.write('Running: %s\n' % cmd)
+    try:
+      libdir = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      print("Error from pkg-config.")
+      return 1
+    sys.stdout.write(libdir.strip())
+    return 0
+
+  if options.dridriverdir:
+    cmd = [options.pkg_config, "--variable=dridriverdir"] + args
+    if options.debug:
+      sys.stderr.write('Running: %s\n' % cmd)
+    try:
+      dridriverdir = subprocess.check_output(cmd).decode('utf-8')
+    except:
+      print("Error from pkg-config.")
+      return 1
+    sys.stdout.write(dridriverdir.strip())
+    return
+
+  cmd = [options.pkg_config, "--cflags", "--libs"] + args
+  if options.debug:
+    sys.stderr.write('Running: %s\n' % ' '.join(cmd))
+
+  try:
+    flag_string = subprocess.check_output(cmd).decode('utf-8')
+  except:
+    sys.stderr.write('Could not run pkg-config.\n')
+    return 1
+
+  # For now just split on spaces to get the args out. This will break if
+  # pkgconfig returns quoted things with spaces in them, but that doesn't seem
+  # to happen in practice.
+  all_flags = flag_string.strip().split(' ')
+
+
+  sysroot = options.sysroot
+  if not sysroot:
+    sysroot = ''
+
+  includes = []
+  cflags = []
+  libs = []
+  lib_dirs = []
+
+  for flag in all_flags[:]:
+    if len(flag) == 0 or MatchesAnyRegexp(flag, strip_out):
+      continue;
+
+    if flag[:2] == '-l':
+      libs.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:2] == '-L':
+      lib_dirs.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:2] == '-I':
+      includes.append(RewritePath(flag[2:], prefix, sysroot))
+    elif flag[:3] == '-Wl':
+      # Don't allow libraries to control ld flags.  These should be specified
+      # only in build files.
+      pass
+    elif flag == '-pthread':
+      # Many libs specify "-pthread" which we don't need since we always include
+      # this anyway. Removing it here prevents a bunch of duplicate inclusions
+      # on the command line.
+      pass
+    else:
+      cflags.append(flag)
+
+  # Output a GN array, the first one is the cflags, the second are the libs. The
+  # JSON formatter prints GN compatible lists when everything is a list of
+  # strings.
+  print(json.dumps([includes, cflags, libs, lib_dirs]))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/pkg-config/pkg-config.py
+++ b/pkg-config/pkg-config.py
@@ -61,6 +61,7 @@ def SetConfigPath(options):
 
   libdir = sysroot + '/usr/' + options.system_libdir + '/pkgconfig'
   libdir += ':' + sysroot + '/usr/share/pkgconfig'
+  libdir = libdir.replace('/', os.sep)
   os.environ['PKG_CONFIG_LIBDIR'] = libdir
   return libdir
 
@@ -106,17 +107,15 @@ def RewritePath(path, strip_prefix, sysroot):
 
 
 def main():
-  # If this is run on non-Linux platforms, just return nothing and indicate
-  # success. This allows us to "kind of emulate" a Linux build from other
-  # platforms.
-  if "linux" not in sys.platform and "darwin" not in sys.platform:
-    print("[[],[],[],[],[]]")
-    return 0
-
   parser = OptionParser()
   parser.add_option('-d', '--debug', action='store_true')
-  parser.add_option('-p', action='store', dest='pkg_config', type='string',
-                    default='pkg-config')
+  if "windows" in sys.platform:
+    parser.add_option('-p', action='store', dest='pkg_config', type='string',
+                      default='pkg-config.exe')
+  else:
+    parser.add_option('-p', action='store', dest='pkg_config', type='string',
+                      default='pkg-config')
+
   parser.add_option('-v', action='append', dest='strip_out', type='string')
   parser.add_option('-s', action='store', dest='sysroot', type='string')
   parser.add_option('-a', action='store', dest='arch', type='string')

--- a/toolchain/android/BUILD.gn
+++ b/toolchain/android/BUILD.gn
@@ -80,7 +80,6 @@ template("android_gcc_toolchains_helper") {
 
 android_gcc_toolchains_helper("x86") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib/i686-linux-android"
   toolchain_args = {
     current_cpu = "x86"
@@ -89,7 +88,6 @@ android_gcc_toolchains_helper("x86") {
 
 android_gcc_toolchains_helper("arm") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib/i686-linux-android"
   toolchain_args = {
     current_cpu = "arm"
@@ -98,7 +96,6 @@ android_gcc_toolchains_helper("arm") {
 
 android_gcc_toolchains_helper("mipsel") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib/mipsel-linux-android"
   toolchain_args = {
     current_cpu = "mipsel"
@@ -107,7 +104,6 @@ android_gcc_toolchains_helper("mipsel") {
 
 android_gcc_toolchains_helper("x64") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib64/x86_64-linux-android"
   toolchain_args = {
     current_cpu = "x64"
@@ -116,7 +112,6 @@ android_gcc_toolchains_helper("x64") {
 
 android_gcc_toolchains_helper("arm64") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib/aarch64-linux-android"
   toolchain_args = {
     current_cpu = "arm64"
@@ -125,7 +120,6 @@ android_gcc_toolchains_helper("arm64") {
 
 android_gcc_toolchains_helper("mips64el") {
   toolchain_root = android_toolchain_root
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
   lib_dir = "usr/lib64/mips64el-linux-android"
   toolchain_args = {
     current_cpu = "mips64el"

--- a/toolchain/android/BUILD.gn
+++ b/toolchain/android/BUILD.gn
@@ -29,7 +29,7 @@ template("android_gcc_toolchain") {
 
     # Make our manually injected libs relative to the build dir.
     _ndk_lib =
-        rebase_path(invoker.sysroot + "/" + invoker.lib_dir, root_build_dir)
+        rebase_path(invoker.sysroot + "/" + invoker.lib_dir + "/" + android_sdk_version, root_build_dir)
 
     libs_section_prefix = "$_ndk_lib/crtbegin_dynamic.o"
     libs_section_postfix = "$_ndk_lib/crtend_android.o"
@@ -37,8 +37,7 @@ template("android_gcc_toolchain") {
     solink_libs_section_prefix = "$_ndk_lib/crtbegin_so.o"
     solink_libs_section_postfix = "$_ndk_lib/crtend_so.o"
 
-    _android_tool_prefix =
-        "${invoker.toolchain_root}/bin/${invoker.binary_prefix}-"
+    _android_tool_prefix = "${invoker.toolchain_root}/bin/"
 
     # The tools should be run relative to the build dir.
     _tool_prefix = rebase_path("$_android_tool_prefix", root_build_dir)
@@ -51,19 +50,17 @@ template("android_gcc_toolchain") {
       toolchain_uses_clang = is_clang
     }
 
-    if (toolchain_uses_clang) {
-      _prefix = rebase_path("$clang_base_path/bin", root_build_dir)
-      cc = "$_prefix/clang"
-      cxx = "$_prefix/clang++"
-    } else {
-      cc = "${_tool_prefix}gcc"
-      cxx = "${_tool_prefix}g++"
-    }
-    ar = _tool_prefix + "ar"
-    ld = cxx
-    readelf = _tool_prefix + "readelf"
-    nm = _tool_prefix + "nm"
-    strip = "${_tool_prefix}strip"
+    assert(toolchain_uses_clang, "We support clang toolchain only")
+
+    #_prefix = rebase_path("$clang_base_path/bin/", root_build_dir)
+    _prefix = _tool_prefix
+    cc = _prefix + "clang"
+    cxx = _prefix + "clang++"
+    ar = _tool_prefix + "llvm-ar"
+    ld = cc
+    readelf = _tool_prefix + "llvm-readelf"
+    nm = _tool_prefix + "llvm-nm"
+    strip = _tool_prefix + "llvm-strip"
 
     # Don't use .cr.so for loadable_modules since they are always loaded via
     # absolute path.
@@ -72,72 +69,64 @@ template("android_gcc_toolchain") {
 }
 
 template("android_gcc_toolchains_helper") {
-  android_gcc_toolchain("android_$target_name") {
-    forward_variables_from(invoker, "*")
-    toolchain_args.is_clang = false
-  }
-
   android_gcc_toolchain("android_clang_$target_name") {
     forward_variables_from(invoker, "*")
+    if (clang_base_path != "") {
+      toolchain_root = clang_base_path
+    }
     toolchain_args.is_clang = true
   }
 }
 
 android_gcc_toolchains_helper("x86") {
-  toolchain_root = x86_android_toolchain_root
-  sysroot = "$android_ndk_root/$x86_android_sysroot_subdir"
-  lib_dir = "usr/lib"
-  binary_prefix = "i686-linux-android"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib/i686-linux-android"
   toolchain_args = {
     current_cpu = "x86"
   }
 }
 
 android_gcc_toolchains_helper("arm") {
-  toolchain_root = arm_android_toolchain_root
-  sysroot = "$android_ndk_root/$arm_android_sysroot_subdir"
-  lib_dir = "usr/lib"
-  binary_prefix = "arm-linux-androideabi"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib/i686-linux-android"
   toolchain_args = {
     current_cpu = "arm"
   }
 }
 
 android_gcc_toolchains_helper("mipsel") {
-  toolchain_root = mips_android_toolchain_root
-  sysroot = "$android_ndk_root/$mips_android_sysroot_subdir"
-  lib_dir = "usr/lib"
-  binary_prefix = "mipsel-linux-android"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib/mipsel-linux-android"
   toolchain_args = {
     current_cpu = "mipsel"
   }
 }
 
 android_gcc_toolchains_helper("x64") {
-  toolchain_root = x86_64_android_toolchain_root
-  sysroot = "$android_ndk_root/$x86_64_android_sysroot_subdir"
-  lib_dir = "usr/lib64"
-  binary_prefix = "x86_64-linux-android"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib64/x86_64-linux-android"
   toolchain_args = {
     current_cpu = "x64"
   }
 }
 
 android_gcc_toolchains_helper("arm64") {
-  toolchain_root = arm64_android_toolchain_root
-  sysroot = "$android_ndk_root/$arm64_android_sysroot_subdir"
-  lib_dir = "usr/lib"
-  binary_prefix = "aarch64-linux-android"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib/aarch64-linux-android"
   toolchain_args = {
     current_cpu = "arm64"
   }
 }
 
 android_gcc_toolchains_helper("mips64el") {
-  toolchain_root = mips64_android_toolchain_root
-  sysroot = "$android_ndk_root/$mips64_android_sysroot_subdir"
-  lib_dir = "usr/lib64"
-  binary_prefix = "mips64el-linux-android"
+  toolchain_root = android_toolchain_root
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
+  lib_dir = "usr/lib64/mips64el-linux-android"
   toolchain_args = {
     current_cpu = "mips64el"
   }

--- a/toolchain/android/settings.gni
+++ b/toolchain/android/settings.gni
@@ -5,24 +5,18 @@
 # This file contains common system config stuff for the Android build.
 
 declare_args() {
-  android_ndk_root = "$external/android_tools/ndk"
-  android_ndk_version = "r25b"
-  android_ndk_major_version = 25
-
-  android_sdk_root = "$external/android_tools/sdk"
   android_sdk_version = "24"
-  android_sdk_build_tools_version = "24.0.2"
-
-  lint_android_sdk_root = "$external/android_tools/sdk"
-  lint_android_sdk_version = "24"
 
   # Libc++ library directory. Override to use a custom libc++ binary.
-  android_libcpp_lib_dir = ""
+  # android_libcpp_lib_dir = ""
 
   # Adds intrumentation to each function. Writes a file with the order that
   # functions are called at startup.
   use_order_profiling = false
 }
+
+import("//build/toolchain/clang.gni")
+import("//build/toolchain/sysroot.gni")
 
 # Host stuff -----------------------------------------------------------------
 
@@ -54,28 +48,18 @@ if (host_os == "linux") {
 # than just the current one) since these are needed by the Android toolchain
 # file to define toolchains for all possible targets in one pass.
 
-android_sdk = "${android_sdk_root}/platforms/android-${android_sdk_version}"
-
 # Path to the Android NDK and SDK.
-android_ndk_include_dir = "$android_ndk_root/usr/include"
-
-android_sdk_tools = "${android_sdk_root}/tools"
-android_sdk_build_tools =
-    "${android_sdk_root}/build-tools/$android_sdk_build_tools_version"
-
-# Path to the SDK's android.jar
-android_sdk_jar = "$android_sdk/android.jar"
-
-zipalign_path = "$android_sdk_build_tools/zipalign"
+android_ndk_include_dir = "$sysroot/usr/include"
 
 # Subdirectories inside android_ndk_root that contain the sysroot for the
 # associated platform.
 # If you raise this, reevaluate the snprintf=snprintf in ./BUILD.gn.
-android_sysroot_subdir = "toolchains/llvm/prebuilt/${android_host_os}-${android_host_arch}/sysroot"
+# android_sysroot_subdir = sysroot
 
 # Toolchain root directory for each build. The actual binaries are inside
 # a "bin" directory inside of these.
-android_toolchain_root = "$android_ndk_root/toolchains/llvm/prebuilt/${android_host_os}-${android_host_arch}"
+android_toolchain_root = clang_base_path
+android_toolchain_resource_dir = clang_resource_dir
 
 # Location of libgcc. This is only needed for the current GN toolchain, so we
 # only need to define the current one, rather than one for every platform
@@ -104,7 +88,7 @@ if (current_cpu == "x86") {
 
 # Toolchain stuff ------------------------------------------------------------
 
-android_libcpp_root = "$android_ndk_root/sources/cxx-stl/llvm-libc++"
+#android_libcpp_root = "$android_ndk_root/sources/cxx-stl/llvm-libc++"
 
 # ABI ------------------------------------------------------------------------
 
@@ -129,9 +113,9 @@ if (current_cpu == "x86") {
   assert(false, "Unknown Android ABI: " + current_cpu)
 }
 
-if (android_libcpp_lib_dir == "") {
-  android_libcpp_lib_dir = "${android_libcpp_root}/libs/${android_app_abi}"
-}
+# if (android_libcpp_lib_dir == "") {
+#   android_libcpp_lib_dir = "${android_libcpp_root}/libs/${android_app_abi}"
+# }
 
 # Secondary ABI -------------------------------------------------------------
 if (target_cpu == "arm64" || target_cpu == "x64" || target_cpu == "mips64el") {

--- a/toolchain/android/settings.gni
+++ b/toolchain/android/settings.gni
@@ -6,8 +6,8 @@
 
 declare_args() {
   android_ndk_root = "$external/android_tools/ndk"
-  android_ndk_version = "r12b"
-  android_ndk_major_version = 12
+  android_ndk_version = "r25b"
+  android_ndk_major_version = 25
 
   android_sdk_root = "$external/android_tools/sdk"
   android_sdk_version = "24"
@@ -71,31 +71,11 @@ zipalign_path = "$android_sdk_build_tools/zipalign"
 # Subdirectories inside android_ndk_root that contain the sysroot for the
 # associated platform.
 # If you raise this, reevaluate the snprintf=snprintf in ./BUILD.gn.
-_android_api_level = 16
-x86_android_sysroot_subdir = "platforms/android-${_android_api_level}/arch-x86"
-arm_android_sysroot_subdir = "platforms/android-${_android_api_level}/arch-arm"
-mips_android_sysroot_subdir =
-    "platforms/android-${_android_api_level}/arch-mips"
-
-# If you raise this, reevaluate the snprintf=snprintf in ./BUILD.gn.
-_android64_api_level = 21
-x86_64_android_sysroot_subdir =
-    "platforms/android-${_android64_api_level}/arch-x86_64"
-arm64_android_sysroot_subdir =
-    "platforms/android-${_android64_api_level}/arch-arm64"
-mips64_android_sysroot_subdir =
-    "platforms/android-${_android64_api_level}/arch-mips64"
+android_sysroot_subdir = "toolchains/llvm/prebuilt/${android_host_os}-${android_host_arch}/sysroot"
 
 # Toolchain root directory for each build. The actual binaries are inside
 # a "bin" directory inside of these.
-_android_toolchain_version = "4.9"
-_android_toolchain_detailed_version = "4.9.x"
-x86_android_toolchain_root = "$android_ndk_root/toolchains/x86-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-arm_android_toolchain_root = "$android_ndk_root/toolchains/arm-linux-androideabi-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-mips_android_toolchain_root = "$android_ndk_root/toolchains/mipsel-linux-android-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-x86_64_android_toolchain_root = "$android_ndk_root/toolchains/x86_64-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-arm64_android_toolchain_root = "$android_ndk_root/toolchains/aarch64-linux-android-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
-mips64_android_toolchain_root = "$android_ndk_root/toolchains/mips64el-linux-android-${_android_toolchain_version}/prebuilt/${android_host_os}-${android_host_arch}"
+android_toolchain_root = "$android_ndk_root/toolchains/llvm/prebuilt/${android_host_os}-${android_host_arch}"
 
 # Location of libgcc. This is only needed for the current GN toolchain, so we
 # only need to define the current one, rather than one for every platform
@@ -103,42 +83,24 @@ mips64_android_toolchain_root = "$android_ndk_root/toolchains/mips64el-linux-and
 if (current_cpu == "x86") {
   android_prebuilt_arch = "android-x86"
   _binary_prefix = "i686-linux-android"
-  android_toolchain_root = "$x86_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/i686-linux-android/${_android_toolchain_detailed_version}/libgcc.a"
 } else if (current_cpu == "arm") {
   android_prebuilt_arch = "android-arm"
   _binary_prefix = "arm-linux-androideabi"
-  android_toolchain_root = "$arm_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/arm-linux-androideabi/${_android_toolchain_detailed_version}/libgcc.a"
 } else if (current_cpu == "mipsel") {
   android_prebuilt_arch = "android-mips"
   _binary_prefix = "mipsel-linux-android"
-  android_toolchain_root = "$mips_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/mipsel-linux-android/${_android_toolchain_detailed_version}/libgcc.a"
 } else if (current_cpu == "x64") {
   android_prebuilt_arch = "android-x86_64"
   _binary_prefix = "x86_64-linux-android"
-  android_toolchain_root = "$x86_64_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/x86_64-linux-android/${_android_toolchain_detailed_version}/libgcc.a"
 } else if (current_cpu == "arm64") {
   android_prebuilt_arch = "android-arm64"
   _binary_prefix = "aarch64-linux-android"
-  android_toolchain_root = "$arm64_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/aarch64-linux-android/${_android_toolchain_detailed_version}/libgcc.a"
 } else if (current_cpu == "mips64el") {
   android_prebuilt_arch = "android-mips64"
   _binary_prefix = "mips64el-linux-android"
-  android_toolchain_root = "$mips64_android_toolchain_root"
-  android_libgcc_file = "$android_toolchain_root/lib/gcc/mips64el-linux-android/${_android_toolchain_detailed_version}/libgcc.a"
 } else {
   assert(false, "Need android libgcc support for your target arch.")
 }
-
-android_tool_prefix = "$android_toolchain_root/bin/$_binary_prefix-"
-android_readelf = "${android_tool_prefix}readelf"
-android_objcopy = "${android_tool_prefix}objcopy"
-android_gdbserver =
-    "$android_ndk_root/prebuilt/$android_prebuilt_arch/gdbserver/gdbserver"
 
 # Toolchain stuff ------------------------------------------------------------
 

--- a/toolchain/apple/linker_driver.py
+++ b/toolchain/apple/linker_driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2016 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/toolchain/apple/toolchain.gni
+++ b/toolchain/apple/toolchain.gni
@@ -11,6 +11,7 @@ import("//build/toolchain/clang.gni")
 import("//build/toolchain/cc_wrapper.gni")
 import("//build/toolchain/coverage.gni")
 import("//build/toolchain/toolchain.gni")
+import("//build/toolchain/posix/settings.gni")
 
 assert((target_os == "ios" && host_os == "mac") || host_os != "win")
 
@@ -147,6 +148,11 @@ template("apple_toolchain") {
 
     # Specify an explicit path for the strip binary.
     _strippath = invoker.bin_path + "strip"
+    # Use the strip GN arg (e.g. llvm-strip) when overridden for
+    # cross-compilation from a non-macOS host.
+    if (strip != "strip") {
+      _strippath = strip
+    }
     linker_driver += " -Wcrl,strippath," + _strippath
 
     if (mac_deterministic_build) {

--- a/toolchain/apple/toolchain.gni
+++ b/toolchain/apple/toolchain.gni
@@ -93,13 +93,17 @@ template("apple_toolchain") {
     if (toolchain_uses_xcode_clang) {
       prefix = invoker.bin_path
     } else {
-      prefix = rebase_path("$clang_base_path/bin/", root_build_dir)
+      if (clang_base_path != "") {
+        prefix = rebase_path("$clang_base_path/bin/", root_build_dir)
+      } else {
+        prefix = ""
+      }
     }
 
     _cc = "${prefix}clang"
     _cxx = "${prefix}clang++"
 
-    swiftmodule_switch = "-Wl,-add_ast_path,"
+    #swiftmodule_switch = "-Wl,-add_ast_path,"
 
     # Compute the compiler prefix.
     if (toolchain_cc_wrapper != "") {
@@ -110,7 +114,7 @@ template("apple_toolchain") {
 
     cc = compiler_prefix + _cc
     cxx = compiler_prefix + _cxx
-    ld = _cxx
+    ld = cxx
 
     # Set the explicit search path for clang++ so it uses the right linker
     # binary.
@@ -307,7 +311,8 @@ template("apple_toolchain") {
       link_command = "$linker_driver $ld -shared "
       link_command += " -Wl,-install_name,@rpath/\"{{target_output_name}}{{output_extension}}\" "
       link_command += dsym_switch
-      link_command += "{{ldflags}} -o \"$dylib\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
+      link_command += "{{ldflags}} -o \"$dylib\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{solibs}} {{libs}}"
+      #link_command += "{{ldflags}} -o \"$dylib\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
 
       replace_command = "if ! cmp -s \"$temporary_tocname\" \"$tocname\"; then mv \"$temporary_tocname\" \"$tocname\""
       extract_toc_command = "{ $otool -l \"$dylib\" | grep LC_ID_DYLIB -A 5; $nm -gPp \"$dylib\" | cut -f1-2 -d' ' | grep -v U\$\$; true; }"
@@ -357,7 +362,8 @@ template("apple_toolchain") {
       link_command = "$linker_driver $ld -bundle {{ldflags}} -o \"$sofile\" -Wl,-filelist,\"$rspfile\""
       link_command += " -Wl,-install_name,@rpath/{{target_output_name}}{{output_extension}}"
       link_command += dsym_switch
-      link_command += " {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
+      link_command += " {{frameworks}} {{solibs}} {{libs}}"
+      #link_command += " {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
       command = link_command
 
       rspfile_content = "{{inputs_newline}}"
@@ -393,7 +399,8 @@ template("apple_toolchain") {
       # do for command-line arguments. Thus any source names with spaces, or
       # label names with spaces (which GN bases the output paths on) will be
       # corrupted by this process. Don't use spaces for source files or labels.
-      command = "$linker_driver $ld $dsym_switch {{ldflags}} -o \"$outfile\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
+      command = "$linker_driver $ld $dsym_switch {{ldflags}} -o \"$outfile\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{solibs}} {{libs}}"
+      #command = "$linker_driver $ld $dsym_switch {{ldflags}} -o \"$outfile\" -Wl,-filelist,\"$rspfile\" {{frameworks}} {{swiftmodules}} {{solibs}} {{libs}}"
       description = "LINK $outfile"
       rspfile_content = "{{inputs_newline}}"
       outputs = [ outfile ]

--- a/toolchain/clang.gni
+++ b/toolchain/clang.gni
@@ -18,6 +18,9 @@ declare_args() {
   # http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html
   # TODO(tim): Supported on Windows?
   use_thin_lto = false
+
+  # Value of --gcc-toolchain
+  gcc_toolchain = ""
 }
 
 if (is_win && is_clang) {

--- a/toolchain/clang.gni
+++ b/toolchain/clang.gni
@@ -9,6 +9,8 @@ declare_args() {
   # The path of your Clang installation folder (without /bin).
   clang_base_path = ""
 
+  clang_resource_dir = ""
+
   # Set to true to use lld, the LLVM linker.
   use_lld = false
 

--- a/toolchain/clang_static_analyzer_wrapper.py
+++ b/toolchain/clang_static_analyzer_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2017 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/compiler_version.gni
+++ b/toolchain/compiler_version.gni
@@ -32,9 +32,7 @@ declare_args() {
 
 if (gcc_version == 0 && !is_clang && !is_win) {
   if (is_android) {
-    # sync with //build/toolchain/android/BUILD.gn
-    import("//build/toolchain/android/settings.gni")
-    _exe = "${android_tool_prefix}gcc"
+    assert(false, "GCC builds are not supported")
   } else if (is_posix) {
     import("//build/toolchain/posix/settings.gni")
     _exe = gcc_cc
@@ -51,9 +49,8 @@ if (gcc_version == 0 && !is_clang && !is_win) {
 
 if (clang_version == 0 && is_clang && !is_win) {
   if (is_android) {
-    # sync with //build/toolchain/android/BUILD.gn
-    import("//build/toolchain/clang.gni")
-    _exe = "$clang_base_path/bin/clang"
+    import("//build/toolchain/android/settings.gni")
+    _exe = "$android_toolchain_root/bin/clang"
   } else if (is_posix) {
     import("//build/toolchain/posix/settings.gni")
     _exe = clang_cc

--- a/toolchain/gcc_ar_wrapper.py
+++ b/toolchain/gcc_ar_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/gcc_compile_wrapper.py
+++ b/toolchain/gcc_compile_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2016 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/gcc_link_wrapper.py
+++ b/toolchain/gcc_link_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/gcc_solink_wrapper.py
+++ b/toolchain/gcc_solink_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2015 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/gcc_toolchain.gni
+++ b/toolchain/gcc_toolchain.gni
@@ -133,6 +133,12 @@ template("gcc_toolchain") {
     } else {
       nm = "nm"
     }
+    if (defined(invoker.strip)) {
+      strip = invoker.strip
+    } else {
+      strip = "strip"
+    }
+    strip = strip # avoid 'Assignment had no effect' above if strip was not used
 
     if (defined(invoker.shlib_extension)) {
       default_shlib_extension = invoker.shlib_extension
@@ -274,7 +280,7 @@ template("gcc_toolchain") {
       rspfile = sofile + ".rsp"
       pool = "//build/toolchain:link_pool($default_toolchain)"
 
-      if (defined(invoker.strip)) {
+      if (symbol_level == 0) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
       } else {
         unstripped_sofile = sofile
@@ -300,8 +306,9 @@ template("gcc_toolchain") {
       assert(defined(readelf), "to solink you must have a readelf")
       assert(defined(nm), "to solink you must have an nm")
       strip_switch = ""
-      if (defined(invoker.strip)) {
-        strip_switch = "--strip=${invoker.strip} "
+      if (symbol_level == 0) {
+        assert(defined(strip), "to strip you must have an strip")
+        strip_switch = "--strip=${strip} "
       }
 
       # This needs a Python script to avoid using a complex shell command
@@ -350,7 +357,7 @@ template("gcc_toolchain") {
       rspfile = sofile + ".rsp"
       pool = "//build/toolchain:link_pool($default_toolchain)"
 
-      if (defined(invoker.strip)) {
+      if (symbol_level == 0) {
         unstripped_sofile = "{{root_out_dir}}/lib.unstripped/$soname"
       } else {
         unstripped_sofile = sofile
@@ -358,8 +365,9 @@ template("gcc_toolchain") {
 
       command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" -Wl,-soname=\"$soname\" @\"$rspfile\""
 
-      if (defined(invoker.strip)) {
-        strip_command = "${invoker.strip} --strip-unneeded -o \"$sofile\" \"$unstripped_sofile\""
+      if (symbol_level == 0) {
+        assert(defined(strip), "to strip you must have an strip")
+        strip_command = "${strip} --strip-unneeded -o \"$sofile\" \"$unstripped_sofile\""
         command += " && " + strip_command
       }
       rspfile_content = "-Wl,--whole-archive {{inputs}} {{solibs}} -Wl,--no-whole-archive $solink_libs_section_prefix {{libs}} $solink_libs_section_postfix"
@@ -401,7 +409,7 @@ template("gcc_toolchain") {
 
       default_output_dir = "{{root_out_dir}}"
 
-      if (defined(invoker.strip)) {
+      if (symbol_level == 0) {
         unstripped_outfile = "{{root_out_dir}}/exe.unstripped/$exename"
       }
 
@@ -417,8 +425,9 @@ template("gcc_toolchain") {
       link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" -Wl,--start-group @\"$rspfile\" {{solibs}} -Wl,--end-group $libs_section_prefix {{libs}} $libs_section_postfix"
 
       strip_switch = ""
-      if (defined(invoker.strip)) {
-        strip_switch = " --strip=\"${invoker.strip}\" --unstripped-file=\"$unstripped_outfile\""
+      if (symbol_level == 0) {
+        assert(defined(strip), "to strip you must have an strip")
+        strip_switch = " --strip=\"${strip}\" --unstripped-file=\"$unstripped_outfile\""
       }
 
       link_wrapper =

--- a/toolchain/mac/find_sdk.py
+++ b/toolchain/mac/find_sdk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2012 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/toolchain/mac/mac_sdk.gni
+++ b/toolchain/mac/mac_sdk.gni
@@ -40,11 +40,15 @@ declare_args() {
 
   # If Xcode is not installed, and you are going to build standard C/C++ code only,
   # you should set it to false.
-  mac_use_sdk = true
+  if (host_os == "mac") {
+    mac_use_sdk = true
+  } else {
+    mac_use_sdk = false
+  }
 }
 
 sdk_info_args = []
-if (!use_system_xcode) {
+if (!use_system_xcode && use_xcode_clang) {
   sdk_info_args += [
     "--developer_dir",
     rebase_path(hermetic_xcode_path, "", root_build_dir),

--- a/toolchain/mac/settings.gni
+++ b/toolchain/mac/settings.gni
@@ -9,7 +9,11 @@ declare_args() {
   # Use the system install of Xcode for tools like ibtool, libtool, etc.
   # This does not affect the compiler. When this variable is false, targets will
   # instead use a hermetic install of Xcode.
-  use_system_xcode = true
+  if (host_os == "mac") {
+    use_system_xcode = true
+  } else {
+    use_system_xcode = false
+  }
 
   # The path to the hermetic install of Xcode. Only relevant when
   # use_system_xcode = false.
@@ -17,5 +21,9 @@ declare_args() {
 
   # Compile with Xcode version of clang instead of hermetic version shipped
   # with the build.
-  use_xcode_clang = true
+  if (host_os == "mac") {
+    use_xcode_clang = true
+  } else {
+    use_xcode_clang = false
+  }
 }

--- a/toolchain/posix/BUILD.gn
+++ b/toolchain/posix/BUILD.gn
@@ -9,6 +9,7 @@ gcc_toolchain("clang_x86") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "x86"
@@ -25,6 +26,7 @@ gcc_toolchain("x86") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "x86"
@@ -41,6 +43,7 @@ gcc_toolchain("clang_x64") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "x64"
@@ -57,6 +60,7 @@ gcc_toolchain("x64") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "x64"
@@ -73,6 +77,7 @@ gcc_toolchain("clang_arm") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "arm"
@@ -89,6 +94,7 @@ gcc_toolchain("arm") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "arm"
@@ -105,6 +111,7 @@ gcc_toolchain("clang_arm64") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "arm64"
@@ -121,6 +128,7 @@ gcc_toolchain("arm64") {
   readelf = readelf
   ar = ar
   nm = nm
+  strip = strip
 
   toolchain_args = {
     current_cpu = "arm64"

--- a/toolchain/posix/settings.gni
+++ b/toolchain/posix/settings.gni
@@ -29,7 +29,7 @@ declare_args() {
 
 if (is_clang && clang_cc == 0) {
   if (clang_base_path != "") {
-    clang_cc = "$clang_base_path/clang"
+    clang_cc = "$clang_base_path/bin/clang"
   } else {
     clang_cc = "clang"
   }
@@ -37,7 +37,7 @@ if (is_clang && clang_cc == 0) {
 
 if (is_clang && clang_cxx == 0) {
   if (clang_base_path != "") {
-    clang_cxx = "$clang_base_path/clang++"
+    clang_cxx = "$clang_base_path/bin/clang++"
   } else {
     clang_cxx = "clang++"
   }

--- a/toolchain/posix/settings.gni
+++ b/toolchain/posix/settings.gni
@@ -25,6 +25,9 @@ declare_args() {
 
   # Path of the 'nm' utility.
   nm = "nm"
+
+  # Path of the 'strip' utility.
+  strip = "strip"
 }
 
 if (is_clang && clang_cc == 0) {

--- a/toolchain/posix/toolchain.py
+++ b/toolchain/posix/toolchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import re

--- a/toolchain/sysroot.gni
+++ b/toolchain/sysroot.gni
@@ -16,9 +16,6 @@ declare_args() {
 if (current_os == target_os && current_cpu == target_cpu &&
     target_sysroot != "") {
   sysroot = target_sysroot
-} else if (is_android) {
-  import("//build/toolchain/android/settings.gni")
-  sysroot = "$android_ndk_root/$android_sysroot_subdir"
 } else if (is_mac) {
   import("//build/toolchain/mac/mac_sdk.gni")
   sysroot = mac_sdk_path

--- a/toolchain/sysroot.gni
+++ b/toolchain/sysroot.gni
@@ -18,21 +18,7 @@ if (current_os == target_os && current_cpu == target_cpu &&
   sysroot = target_sysroot
 } else if (is_android) {
   import("//build/toolchain/android/settings.gni")
-  if (current_cpu == "x86") {
-    sysroot = "$android_ndk_root/$x86_android_sysroot_subdir"
-  } else if (current_cpu == "arm") {
-    sysroot = "$android_ndk_root/$arm_android_sysroot_subdir"
-  } else if (current_cpu == "mipsel") {
-    sysroot = "$android_ndk_root/$mips_android_sysroot_subdir"
-  } else if (current_cpu == "x64") {
-    sysroot = "$android_ndk_root/$x86_64_android_sysroot_subdir"
-  } else if (current_cpu == "arm64") {
-    sysroot = "$android_ndk_root/$arm64_android_sysroot_subdir"
-  } else if (current_cpu == "mips64el") {
-    sysroot = "$android_ndk_root/$mips64_android_sysroot_subdir"
-  } else {
-    sysroot = ""
-  }
+  sysroot = "$android_ndk_root/$android_sysroot_subdir"
 } else if (is_mac) {
   import("//build/toolchain/mac/mac_sdk.gni")
   sysroot = mac_sdk_path

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -294,7 +294,7 @@ template("msvc_toolchain") {
 
       # The use of inputs_newline is to work around a fixed per-line buffer
       # size in the linker.
-      rspfile_content = "{{libs}} {{solibs}} {{inputs_newline}} {{ldflags}}"
+      rspfile_content = "{{ldflags}} {{libs}} {{solibs}} {{inputs_newline}} {{ldflags}}"
     }
 
     tool("solink_module") {

--- a/toolchain/win/BUILD.gn
+++ b/toolchain/win/BUILD.gn
@@ -136,7 +136,11 @@ template("msvc_toolchain") {
     # mt.exe in PATH on non-Windows, so it's not needed there anyways.
     if (host_os != "win") {
       linker_wrapper = ""
-      sys_lib_flags = "${invoker.sys_lib_flags} "  # Note trailing space
+      if (defined(invoker.sys_lib_flags)) {
+        sys_lib_flags = "${invoker.sys_lib_flags} "  # Note trailing space
+      } else {
+        sys_lib_flags = ""
+      }
     } else if (defined(invoker.sys_lib_flags)) {
       # Invoke ninja as wrapper instead of tool wrapper, because python
       # invocation requires higher cpu usage compared to ninja invocation, and

--- a/toolchain/win/asm_wrapper.py
+++ b/toolchain/win/asm_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import sys
 from toolchain import GetEnv

--- a/toolchain/win/link_wrapper.py
+++ b/toolchain/win/link_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import re
 import subprocess

--- a/toolchain/win/midl_wrapper.py
+++ b/toolchain/win/midl_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import subprocess
 import sys

--- a/toolchain/win/rc_wrapper.py
+++ b/toolchain/win/rc_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import subprocess
 import sys
 import os

--- a/toolchain/win/recursive_mirror.py
+++ b/toolchain/win/recursive_mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import shutil
 import sys

--- a/toolchain/win/settings.gni
+++ b/toolchain/win/settings.gni
@@ -57,20 +57,24 @@ if (visual_studio_path == "") {
 if (cached_toolchain_data != "") {
   toolchain_data = cached_toolchain_data
 } else {
-  toolchain_data = exec_script("toolchain.py",
-                               [
-                                 "setup_toolchain",
-                                 visual_studio_version,
-                                 visual_studio_path,
-                                 windows_sdk_version,
+  if (host_os == "win") {
+    toolchain_data = exec_script("toolchain.py",
+                                [
+                                  "setup_toolchain",
+                                  visual_studio_version,
+                                  visual_studio_path,
+                                  windows_sdk_version,
 
-                                 # Don't use clang_base_path directly, so we can
-                                 # skip clang detection if not needed
-                                 # (i.e. !is_clang).
-                                 _clang_base_path_arg,
-                                 _clang_msc_ver,
-                               ],
-                               "scope")
+                                  # Don't use clang_base_path directly, so we can
+                                  # skip clang detection if not needed
+                                  # (i.e. !is_clang).
+                                  _clang_base_path_arg,
+                                  _clang_msc_ver,
+                                ],
+                                "scope")
+  } else {
+    toolchain_data = read_file(rebase_path("//.msvc.toolchain"), "scope")
+  }
 }
 
 visual_studio_version = toolchain_data.visual_studio_version

--- a/toolchain/win/settings.gni
+++ b/toolchain/win/settings.gni
@@ -3,6 +3,9 @@ if (is_clang) {
 }
 
 declare_args() {
+  # Use the system install of Visual Studio
+  use_visual_studio = true
+
   # Desired version of Visual Studio.
   # If visual_studio_path is set, this must be
   # the version of the VS installation at the visual_studio_path.
@@ -29,6 +32,12 @@ declare_args() {
 
   # Allows us to avoid multiple toolchain.py invocations for multi-toolchain builds.
   cached_toolchain_data = ""
+
+  visual_c_path = ""
+  windows_sdk_path = ""
+  netfx_sdk_path = ""
+  netfx_sdk_version = ""
+  clang_msc_full_ver = 0
 }
 
 assert(visual_studio_version != "", "visual_studio_version must be non-empty")
@@ -57,7 +66,7 @@ if (visual_studio_path == "") {
 if (cached_toolchain_data != "") {
   toolchain_data = cached_toolchain_data
 } else {
-  if (host_os == "win") {
+  if (use_visual_studio) {
     toolchain_data = exec_script("toolchain.py",
                                 [
                                   "setup_toolchain",
@@ -73,15 +82,55 @@ if (cached_toolchain_data != "") {
                                 ],
                                 "scope")
   } else {
-    toolchain_data = read_file(rebase_path("//.msvc.toolchain"), "scope")
+    # toolchain_data = read_file(rebase_path("//.msvc.toolchain"), "scope")
+    toolchain_data = {
+      msc_ver=clang_msc_ver
+      msc_full_ver=clang_msc_full_ver
+      x86 = {
+        env_filename = ""
+        vc_bin_dir = ""
+        include_flags_I = "\"/I$visual_c_path/include\" \"/I$visual_c_path/atlmfc/include\" \"/I$visual_c_path/auxiliary/vs/include\" \"/I$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/um\" \"/I$windows_sdk_path/include/$windows_sdk_version/shared\" \"/I$windows_sdk_path/include/$windows_sdk_version/winrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"/I$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        include_flags_imsvc = "\"-imsvc$visual_c_path/include\" \"-imsvc$visual_c_path/atlmfc/include\" \"-imsvc$visual_c_path/auxiliary/vs/include\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/um\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/shared\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/winrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"-imsvc$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        vc_lib_path = "$visual_c_path/lib/x86"
+        vc_lib_atlmfc_path = "$visual_c_path/atlmfc/lib/x86"
+        vc_lib_um_path = "$windows_sdk_path/lib/$windows_sdk_version/um/x86"
+        paths = ""
+        libpath_flags = "\"-libpath:$visual_c_path/atlmfc/lib/x86\" \"-libpath:$visual_c_path/lib/x86\" \"-libpath:$netfx_sdk_path/$netfx_sdk_version/lib/um/x86\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/ucrt/x86\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/um/x86\""
+      }
+      x86_uwp = {
+        env_filename = ""
+        vc_bin_dir = ""
+        include_flags_I = "\"/I$visual_c_path/include\" \"/I$visual_c_path/atlmfc/include\" \"/I$visual_c_path/auxiliary/vs/include\" \"/I$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/um\" \"/I$windows_sdk_path/include/$windows_sdk_version/shared\" \"/I$windows_sdk_path/include/$windows_sdk_version/winrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"/I$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        include_flags_imsvc = "\"-imsvc$visual_c_path/include\" \"-imsvc$visual_c_path/atlmfc/include\" \"-imsvc$visual_c_path/auxiliary/vs/include\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/um\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/shared\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/winrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"-imsvc$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        vc_lib_path = "$visual_c_path/lib/x86/store"
+        vc_lib_um_path = "$windows_sdk_path/lib/$windows_sdk_version/um/x86"
+        paths = ""
+        libpath_flags = "\"-libpath:$visual_c_path/lib/x86/store/\" \"-libpath:$netfx_sdk_path/$netfx_sdk_version/lib/um/x86\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/ucrt/x86\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/um/x86\""
+      }
+      x64 = {
+        env_filename = ""
+        vc_bin_dir = ""
+        include_flags_I = "\"/I$visual_c_path/include\" \"/I$visual_c_path/atlmfc/include\" \"/I$visual_c_path/auxiliary/vs/include\" \"/I$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/um\" \"/I$windows_sdk_path/include/$windows_sdk_version/shared\" \"/I$windows_sdk_path/include/$windows_sdk_version/winrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"/I$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        include_flags_imsvc = "\"-imsvc$visual_c_path/include\" \"-imsvc$visual_c_path/atlmfc/include\" \"-imsvc$visual_c_path/auxiliary/vs/include\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/um\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/shared\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/winrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"-imsvc$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        vc_lib_path = "$visual_c_path/lib/x64"
+        vc_lib_atlmfc_path = "$visual_c_path/atlmfc/lib/x64"
+        vc_lib_um_path = "$windows_sdk_path/lib/$windows_sdk_version/um/x64"
+        paths = ""
+        libpath_flags = "\"-libpath:$visual_c_path/atlmfc/lib/x64\" \"-libpath:$visual_c_path/lib/x64\" \"-libpath:$netfx_sdk_path/$netfx_sdk_version/lib/um/x64\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/ucrt/x64\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/um/x64\""
+      }
+      x64_uwp = {
+        env_filename = ""
+        vc_bin_dir = ""
+        include_flags_I = "\"/I$visual_c_path/include\" \"/I$visual_c_path/atlmfc/include\" \"/I$visual_c_path/auxiliary/vs/include\" \"/I$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/um\" \"/I$windows_sdk_path/include/$windows_sdk_version/shared\" \"/I$windows_sdk_path/include/$windows_sdk_version/winrt\" \"/I$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"/I$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        include_flags_imsvc = "\"-imsvc$visual_c_path/include\" \"-imsvc$visual_c_path/atlmfc/include\" \"-imsvc$visual_c_path/auxiliary/vs/include\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/ucrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/um\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/shared\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/winrt\" \"-imsvc$windows_sdk_path/include/$windows_sdk_version/cppwinrt\" \"-imsvc$netfx_sdk_path/$netfx_sdk_version/include/um\""
+        vc_lib_path = "$visual_c_path/lib/x64/store"
+        vc_lib_um_path = "$windows_sdk_path/lib/$windows_sdk_version/um/x64"
+        paths = ""
+        libpath_flags = "\"-libpath:$visual_c_path/lib/x64/store/\" \"-libpath:$netfx_sdk_path/$netfx_sdk_version/lib/um/x64\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/ucrt/x64\" \"-libpath:$windows_sdk_path/lib/$windows_sdk_version/um/x64\""
+      }
+    }
   }
 }
-
-visual_studio_version = toolchain_data.visual_studio_version
-visual_studio_path = toolchain_data.visual_studio_path
-
-# Full path to the Windows SDK, not including a backslash at the end.
-windows_sdk_path = toolchain_data.windows_sdk_path
 
 # Value of the _MSC_VER variable.
 # see: https://msdn.microsoft.com/en-us/library/b0084kay.aspx

--- a/toolchain/win/stamp.py
+++ b/toolchain/win/stamp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 def main(path):

--- a/toolchain/win/toolchain.py
+++ b/toolchain/win/toolchain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.


### PR DESCRIPTION
- Add --gcc-toolchain to clang flags if sysroot is used (sometimes clang is unable to auto-detect gcc toolchain)
- Add gcc_toolchain option for clang - for the case when you are cross-compiling on Ubuntu for Ubuntu via Ubuntu's multiach support (without use_sysroot=true)
- Add dwarf_version argument for clang - dwarf 4+ is not always compatible with binutils used for target OS
- Set clang's --target for x86/x64 linux builds too - in case of cross-compilation when host and target cpu are the same (x86_64) but OSes are different clang used host tools to compile (in case of x86_64-apple-darwin21.4.0 to x86_64-linux-gnu cross compilation the host's stuff was used)
- Initial win/clang cross-compilation support (macOS/Linux=>Windows). Currently requires //.msvc.toolchain file that should have toolchain data in the same format as toolchain/win/toolchain.py outputs